### PR TITLE
PPLUS-1176: Message contains the project prefix twice

### DIFF
--- a/src/CodeCompliance/Domain/Checks/NotUnique/Method.php
+++ b/src/CodeCompliance/Domain/Checks/NotUnique/Method.php
@@ -28,7 +28,7 @@ class Method extends AbstractCodeComplianceCheck
      */
     public function getGuideline(): string
     {
-        return 'Method name %s::%s() should contains project prefix, like %s%s';
+        return 'Method name %s::%s() should contains project prefix, like %s';
     }
 
     /**
@@ -72,8 +72,7 @@ class Method extends AbstractCodeComplianceCheck
                         $this->getGuideline(),
                         $source->getClassName(),
                         $projectMethod->getName(),
-                        strtolower((string)reset($projectPrefixList)),
-                        ucfirst(implode('', $methodParts)),
+                        lcfirst(implode('', $methodParts))
                     );
                     $violations[] = new Violation(new Id(), $guideline, $this->getName());
                 }

--- a/src/CodeCompliance/Domain/Checks/NotUnique/Method.php
+++ b/src/CodeCompliance/Domain/Checks/NotUnique/Method.php
@@ -72,7 +72,7 @@ class Method extends AbstractCodeComplianceCheck
                         $this->getGuideline(),
                         $source->getClassName(),
                         $projectMethod->getName(),
-                        lcfirst(implode('', $methodParts))
+                        lcfirst(implode('', $methodParts)),
                     );
                     $violations[] = new Violation(new Id(), $guideline, $this->getName());
                 }


### PR DESCRIPTION
- Ticket: https://spryker.atlassian.net/browse/PPLUS-1176

### Bugfix

- Fixed the behavior when error message show project specific prefix twice.