### PR TITLE
Fix up phpstan

### DIFF
--- a/phpstan.json
+++ b/phpstan.json
@@ -1,3 +1,0 @@
-{
-  "defaultLevel": 8
-}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,7 @@
 parameters:
+    level: 8
     checkMissingIterableValueType: false
     reportUnmatchedIgnoredErrors: false
-    checkGenericClassInNonGenericObjectType: false
 
     bootstrapFiles:
         - phpstan-bootstrap.php

--- a/src/CodeCompliance/Domain/Checks/Filters/PluginFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/PluginFilter.php
@@ -26,10 +26,9 @@ class PluginFilter implements FilterInterface
     }
 
     /**
-     * @template T \Codebase\Application\Dto\CodebaseInterface
-     * @param array<T> $sources
+     * @param array<\Codebase\Application\Dto\CodebaseInterface> $sources
      *
-     * @return array<T>
+     * @return array<\Codebase\Application\Dto\CodebaseInterface>
      */
     public function filter(array $sources): array
     {
@@ -39,7 +38,11 @@ class PluginFilter implements FilterInterface
     }
 
     /**
-     * @param \ReflectionClass<\Codebase\Application\Dto\CodebaseInterface> $class
+     * @phpstan-template T of \Codebase\Application\Dto\CodebaseInterface
+     *
+     * @phpstan-param \ReflectionClass<T> $class
+     *
+     * @param \ReflectionClass $class
      *
      * @return bool
      */

--- a/src/CodeCompliance/Domain/Checks/Filters/PluginFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/PluginFilter.php
@@ -26,9 +26,10 @@ class PluginFilter implements FilterInterface
     }
 
     /**
-     * @param array $sources
+     * @template T \Codebase\Application\Dto\CodebaseInterface
+     * @param array<T> $sources
      *
-     * @return array
+     * @return array<T>
      */
     public function filter(array $sources): array
     {
@@ -38,7 +39,7 @@ class PluginFilter implements FilterInterface
     }
 
     /**
-     * @param \ReflectionClass $class
+     * @param \ReflectionClass<\Codebase\Application\Dto\CodebaseInterface> $class
      *
      * @return bool
      */

--- a/src/CodeCompliance/Domain/Checks/NotUnique/Method.php
+++ b/src/CodeCompliance/Domain/Checks/NotUnique/Method.php
@@ -95,7 +95,9 @@ class Method extends AbstractCodeComplianceCheck
     }
 
     /**
-     * @param array<\ReflectionClass> $interfaces
+     * @template T of object
+     *
+     * @param array<\ReflectionClass<T>> $interfaces
      *
      * @return array<\ReflectionMethod>
      */
@@ -120,8 +122,10 @@ class Method extends AbstractCodeComplianceCheck
     }
 
     /**
+     * @template T of object
+     *
      * @param string $method
-     * @param \ReflectionClass $class
+     * @param \ReflectionClass<T> $class
      *
      * @return bool
      */

--- a/src/CodeCompliance/Domain/Checks/NotUnique/Method.php
+++ b/src/CodeCompliance/Domain/Checks/NotUnique/Method.php
@@ -95,9 +95,11 @@ class Method extends AbstractCodeComplianceCheck
     }
 
     /**
-     * @template T of object
+     * @phpstan-template T of object
      *
-     * @param array<\ReflectionClass<T>> $interfaces
+     * @phpstan-param array<\ReflectionClass<T>> $interfaces
+     *
+     * @param array<\ReflectionClass> $interfaces
      *
      * @return array<\ReflectionMethod>
      */
@@ -122,10 +124,12 @@ class Method extends AbstractCodeComplianceCheck
     }
 
     /**
-     * @template T of object
+     * @phpstan-template T of object
+     *
+     * @phpstan-param \ReflectionClass<T> $class
      *
      * @param string $method
-     * @param \ReflectionClass<T> $class
+     * @param \ReflectionClass $class
      *
      * @return bool
      */

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/AbstractUsedCodeComplianceCheck.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/AbstractUsedCodeComplianceCheck.php
@@ -14,9 +14,11 @@ use ReflectionMethod;
 abstract class AbstractUsedCodeComplianceCheck extends AbstractCodeComplianceCheck
 {
     /**
-     * @template T of object
+     * @phpstan-template T of object
      *
-     * @param \ReflectionClass<T> $class
+     * @phpstan-param \ReflectionClass<T> $class
+     *
+     * @param \ReflectionClass $class
      *
      * @return string|null
      */

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/AbstractUsedCodeComplianceCheck.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/AbstractUsedCodeComplianceCheck.php
@@ -14,7 +14,9 @@ use ReflectionMethod;
 abstract class AbstractUsedCodeComplianceCheck extends AbstractCodeComplianceCheck
 {
     /**
-     * @param \ReflectionClass $class
+     * @template T of object
+     *
+     * @param \ReflectionClass<T> $class
      *
      * @return string|null
      */

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/DependencyInBusinessModel.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/DependencyInBusinessModel.php
@@ -78,9 +78,11 @@ class DependencyInBusinessModel extends AbstractUsedCodeComplianceCheck
     }
 
     /**
-     * @template T of object
+     * @phpstan-template T of object
      *
-     * @param \ReflectionClass<T> $reflectionClass
+     * @phpstan-param \ReflectionClass<T> $reflectionClass
+     *
+     * @param \ReflectionClass $reflectionClass
      * @param string $methodName
      *
      * @return \ReflectionMethod|null

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/DependencyInBusinessModel.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/DependencyInBusinessModel.php
@@ -78,7 +78,9 @@ class DependencyInBusinessModel extends AbstractUsedCodeComplianceCheck
     }
 
     /**
-     * @param \ReflectionClass $reflectionClass
+     * @template T of object
+     *
+     * @param \ReflectionClass<T> $reflectionClass
      * @param string $methodName
      *
      * @return \ReflectionMethod|null

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/PersistenceInBusinessModel.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/PersistenceInBusinessModel.php
@@ -119,13 +119,13 @@ class PersistenceInBusinessModel extends AbstractUsedCodeComplianceCheck
     }
 
     /**
-     * @param array $classNamespaceList
+     * @param array<string> $classNamespaceList
      *
-     * @return array
+     * @return array<string>
      */
     protected function filterRepositoryAndEntityManager(array $classNamespaceList): array
     {
-        return array_filter($classNamespaceList, function ($classNamespace) {
+        return array_filter($classNamespaceList, function (string $classNamespace) {
             return $this->isRepositoryOrEntityManager($classNamespace);
         });
     }
@@ -179,7 +179,9 @@ class PersistenceInBusinessModel extends AbstractUsedCodeComplianceCheck
     }
 
     /**
-     * @param \ReflectionClass $class
+     * @template T of object
+     *
+     * @param \ReflectionClass<T> $class
      * @param string $namespace
      *
      * @return \ReflectionProperty|null
@@ -197,7 +199,9 @@ class PersistenceInBusinessModel extends AbstractUsedCodeComplianceCheck
     }
 
     /**
-     * @param \ReflectionClass $reflectionClass
+     * @template T of object
+     *
+     * @param \ReflectionClass<T> $reflectionClass
      * @param string $methodName
      *
      * @return \ReflectionMethod|null

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/PersistenceInBusinessModel.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/PersistenceInBusinessModel.php
@@ -179,9 +179,11 @@ class PersistenceInBusinessModel extends AbstractUsedCodeComplianceCheck
     }
 
     /**
-     * @template T of object
+     * @phpstan-template T of object
      *
-     * @param \ReflectionClass<T> $class
+     * @phpstan-param \ReflectionClass<T> $class
+     *
+     * @param \ReflectionClass $class
      * @param string $namespace
      *
      * @return \ReflectionProperty|null
@@ -199,9 +201,11 @@ class PersistenceInBusinessModel extends AbstractUsedCodeComplianceCheck
     }
 
     /**
-     * @template T of object
+     * @phpstan-template T of object
      *
-     * @param \ReflectionClass<T> $reflectionClass
+     * @phpstan-param \ReflectionClass<T> $reflectionClass
+     *
+     * @param \ReflectionClass $reflectionClass
      * @param string $methodName
      *
      * @return \ReflectionMethod|null

--- a/src/Codebase/Application/Dto/ClassCodebaseDto.php
+++ b/src/Codebase/Application/Dto/ClassCodebaseDto.php
@@ -9,6 +9,9 @@ namespace Codebase\Application\Dto;
 
 use ReflectionClass;
 
+/**
+ * @phpstan-template T of object
+ */
 class ClassCodebaseDto extends AbstractCodebaseDto
 {
     /**
@@ -32,6 +35,8 @@ class ClassCodebaseDto extends AbstractCodebaseDto
     protected array $traits = [];
 
     /**
+     * @phpstan-var \ReflectionClass<T>
+     *
      * @var \ReflectionClass
      */
     protected ReflectionClass $reflection;
@@ -112,6 +117,8 @@ class ClassCodebaseDto extends AbstractCodebaseDto
     }
 
     /**
+     * @phpstan-return \ReflectionClass<T>
+     *
      * @return \ReflectionClass
      */
     public function getReflection(): ReflectionClass
@@ -120,6 +127,8 @@ class ClassCodebaseDto extends AbstractCodebaseDto
     }
 
     /**
+     * @phpstan-param \ReflectionClass<T> $reflection
+     *
      * @param \ReflectionClass $reflection
      *
      * @return $this

--- a/src/Codebase/Infrastructure/SourceParser/Parser/PhpParser.php
+++ b/src/Codebase/Infrastructure/SourceParser/Parser/PhpParser.php
@@ -18,7 +18,9 @@ use PhpParser\NodeVisitor\CloningVisitor;
 use PhpParser\NodeVisitor\NameResolver;
 use ReflectionClass;
 use Symfony\Component\Finder\Finder;
-
+/**
+ * @phpstan-template T of object
+ */
 class PhpParser implements ParserInterface
 {
     /**
@@ -131,6 +133,10 @@ class PhpParser implements ParserInterface
     }
 
     /**
+     * @phpstan-param \Codebase\Application\Dto\ClassCodebaseDto<T>|null $transfer
+     *
+     * @phpstan-return \Codebase\Application\Dto\ClassCodebaseDto<T>|null
+     *
      * @param string $namespace
      * @param array<string> $projectPrefixList
      * @param array<string> $coreNamespaces
@@ -148,6 +154,7 @@ class PhpParser implements ParserInterface
             if (!class_exists($namespace) && !interface_exists($namespace)) {
                 return null;
             }
+            /** @phpstan-var \ReflectionClass<T> $projectClass */
             $projectClass = new ReflectionClass($namespace);
         } catch (Exception $logicException) {
             return null;
@@ -156,6 +163,7 @@ class PhpParser implements ParserInterface
         }
 
         if ($transfer === null) {
+            /** @phpstan-var \Codebase\Application\Dto\ClassCodebaseDto<T> $transfer */
             $transfer = new ClassCodebaseDto($coreNamespaces);
         }
         $transfer->setClassName($namespace);
@@ -211,6 +219,8 @@ class PhpParser implements ParserInterface
     }
 
     /**
+     * @phpstan-param \ReflectionClass<T> $projectClass
+     *
      * @param \ReflectionClass $projectClass
      * @param array<string> $projectPrefix
      * @param array<string> $coreNamespaces

--- a/src/Codebase/Infrastructure/SourceParser/Parser/PhpParser.php
+++ b/src/Codebase/Infrastructure/SourceParser/Parser/PhpParser.php
@@ -18,6 +18,7 @@ use PhpParser\NodeVisitor\CloningVisitor;
 use PhpParser\NodeVisitor\NameResolver;
 use ReflectionClass;
 use Symfony\Component\Finder\Finder;
+
 /**
  * @phpstan-template T of object
  */


### PR DESCRIPTION
Issues:

```
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   CodeCompliance/Domain/Checks/Filters/PluginFilter.php                                                                                                           
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  45     Method CodeCompliance\Domain\Checks\Filters\PluginFilter::isPlugin() has parameter $class with generic class ReflectionClass but does not specify its types: T  
         💡 You can turn this off by setting checkGenericClassInNonGenericObjectType: false in your phpstan.neon.                                                        
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   CodeCompliance/Domain/Checks/NotUnique/Method.php                                                                                                                           
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  102    Method CodeCompliance\Domain\Checks\NotUnique\Method::getInterfaceMethods() has parameter $interfaces with generic class ReflectionClass but does not specify its types: T  
         💡 You can turn this off by setting checkGenericClassInNonGenericObjectType: false in your phpstan.neon.                                                                    
  128    Method CodeCompliance\Domain\Checks\NotUnique\Method::isTraitMethod() has parameter $class with generic class ReflectionClass but does not specify its types: T             
         💡 You can turn this off by setting checkGenericClassInNonGenericObjectType: false in your phpstan.neon.                                                                    
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   CodeCompliance/Domain/Checks/PrivateApi/Used/AbstractUsedCodeComplianceCheck.php                                                                                                                   
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  21     Method CodeCompliance\Domain\Checks\PrivateApi\Used\AbstractUsedCodeComplianceCheck::getClassFileBody() has parameter $class with generic class ReflectionClass but does not specify its types: T  
         💡 You can turn this off by setting checkGenericClassInNonGenericObjectType: false in your phpstan.neon.                                                                                           
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   CodeCompliance/Domain/Checks/PrivateApi/Used/DependencyInBusinessModel.php                                                                                                                                     
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  86     Method CodeCompliance\Domain\Checks\PrivateApi\Used\DependencyInBusinessModel::getMethodFromCurrentFile() has parameter $reflectionClass with generic class ReflectionClass but does not specify its types: T  
         💡 You can turn this off by setting checkGenericClassInNonGenericObjectType: false in your phpstan.neon.                                                                                                       
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   CodeCompliance/Domain/Checks/PrivateApi/Used/PersistenceInBusinessModel.php                                                                                                                         
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  187    Method CodeCompliance\Domain\Checks\PrivateApi\Used\PersistenceInBusinessModel::getPropertyByNamespace() has parameter $class with generic class ReflectionClass but does not specify its types: T  
         💡 You can turn this off by setting checkGenericClassInNonGenericObjectType: false in your phpstan.neon.                                                                                            
  205    Method CodeCompliance\Domain\Checks\PrivateApi\Used\PersistenceInBusinessModel::getMethod() has parameter $reflectionClass with generic class ReflectionClass but does not specify its types: T     
         💡 You can turn this off by setting checkGenericClassInNonGenericObjectType: false in your phpstan.neon.                                                                                            
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  Line   Codebase/Application/Dto/ClassCodebaseDto.php                                                                                                                     
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  37     Property Codebase\Application\Dto\ClassCodebaseDto::$reflection with generic class ReflectionClass does not specify its types: T                                  
         💡 You can turn this off by setting checkGenericClassInNonGenericObjectType: false in your phpstan.neon.                                                          
  117    Method Codebase\Application\Dto\ClassCodebaseDto::getReflection() return type with generic class ReflectionClass does not specify its types: T                    
         💡 You can turn this off by setting checkGenericClassInNonGenericObjectType: false in your phpstan.neon.                                                          
  127    Method Codebase\Application\Dto\ClassCodebaseDto::setReflection() has parameter $reflection with generic class ReflectionClass but does not specify its types: T  
         💡 You can turn this off by setting checkGenericClassInNonGenericObjectType: false in your phpstan.neon.                                                          
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   Codebase/Infrastructure/SourceParser/Parser/PhpParser.php                                                                                                                      
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  220    Method Codebase\Infrastructure\SourceParser\Parser\PhpParser::isExtendCore() has parameter $projectClass with generic class ReflectionClass but does not specify its types: T  
         💡 You can turn this off by setting checkGenericClassInNonGenericObjectType: false in your phpstan.neon.                                                                       
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```


In a follow up step we also need to remove

    checkMissingIterableValueType: false

then