### PR TITLE
Activate CI checks on php 7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         php-version: [
             '7.4',
-            '8.0',
             '8.1'
         ]
 
@@ -26,7 +25,7 @@ jobs:
           extensions: mbstring, intl
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Composer validate
         run: composer validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version: [
+            '7.4',
             '8.0',
             '8.1'
         ]


### PR DESCRIPTION
Since spryker-sdk/upgrader should be compatible with php 7.4, the CI checks should be also done for php 7.4.