### PR TITLE
PPLUS-1583: Introduce strict_types usage in project

### DIFF
--- a/app/Kernel.php
+++ b/app/Kernel.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2019-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace App;
 

--- a/app/Kernel.php
+++ b/app/Kernel.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace App;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;

--- a/app/Kernel.php
+++ b/app/Kernel.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2019-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace App;
 

--- a/composer.lock
+++ b/composer.lock
@@ -7658,12 +7658,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/code-sniffer.git",
-                "reference": "0a5b711cc4f689d5cca4cacb6217b42d9dbbf2de"
+                "reference": "892b925aec2e2c5f67a86f6248d47be6d6787574"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/code-sniffer/zipball/0a5b711cc4f689d5cca4cacb6217b42d9dbbf2de",
-                "reference": "0a5b711cc4f689d5cca4cacb6217b42d9dbbf2de",
+                "url": "https://api.github.com/repos/spryker/code-sniffer/zipball/892b925aec2e2c5f67a86f6248d47be6d6787574",
+                "reference": "892b925aec2e2c5f67a86f6248d47be6d6787574",
                 "shasum": ""
             },
             "require": {
@@ -7709,7 +7709,7 @@
                 "issues": "https://github.com/spryker/code-sniffer/issues",
                 "source": "https://github.com/spryker/code-sniffer"
             },
-            "time": "2022-09-04T15:35:37+00:00"
+            "time": "2022-09-23T12:56:46+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -7890,5 +7890,5 @@
         "ext-simplexml": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -18,4 +18,8 @@
 
     <rule ref="vendor/spryker/code-sniffer/SprykerStrict/ruleset.xml"/>
 
+    <rule ref="Generic.PHP.RequireStrictTypes">
+        <exclude-pattern>tests/bootstrap.php</exclude-pattern>
+    </rule>
+
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -18,14 +18,4 @@
 
     <rule ref="vendor/spryker/code-sniffer/SprykerStrict/ruleset.xml"/>
 
-    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
-        <exclude-pattern>tests/bootstrap.php</exclude-pattern>
-        <properties>
-            <property name="declareOnFirstLine" type="bool" value="false"/>
-            <property name="linesCountBeforeDeclare" type="int" value="1"/>
-            <property name="linesCountAfterDeclare" type="int" value="1"/>
-            <property name="spacesCountAroundEqualsSign" type="int" value="0"/>
-        </properties>
-    </rule>
-
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -18,4 +18,9 @@
 
     <rule ref="vendor/spryker/code-sniffer/SprykerStrict/ruleset.xml"/>
 
+    <rule ref="Spryker.PHP.DeclareStrictTypesAfterFileDoc">
+        <properties>
+            <property name="strictTypesMandatory" value="true"/>
+        </properties>
+    </rule>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -18,8 +18,14 @@
 
     <rule ref="vendor/spryker/code-sniffer/SprykerStrict/ruleset.xml"/>
 
-    <rule ref="Generic.PHP.RequireStrictTypes">
+    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
         <exclude-pattern>tests/bootstrap.php</exclude-pattern>
+        <properties>
+            <property name="declareOnFirstLine" type="bool" value="false"/>
+            <property name="linesCountBeforeDeclare" type="int" value="1"/>
+            <property name="linesCountAfterDeclare" type="int" value="1"/>
+            <property name="spacesCountAroundEqualsSign" type="int" value="0"/>
+        </properties>
     </rule>
 
 </ruleset>

--- a/src/CodeCompliance/Application/Checks/CodeComplianceCheckInterface.php
+++ b/src/CodeCompliance/Application/Checks/CodeComplianceCheckInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks;
 

--- a/src/CodeCompliance/Application/Checks/CodeComplianceCheckInterface.php
+++ b/src/CodeCompliance/Application/Checks/CodeComplianceCheckInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks;
 

--- a/src/CodeCompliance/Application/Checks/CodeComplianceCheckInterface.php
+++ b/src/CodeCompliance/Application/Checks/CodeComplianceCheckInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Application\Checks;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/src/CodeCompliance/Application/Checks/NotUnique/ConstantCheck.php
+++ b/src/CodeCompliance/Application/Checks/NotUnique/ConstantCheck.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Application\Checks\NotUnique;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/src/CodeCompliance/Application/Checks/NotUnique/ConstantCheck.php
+++ b/src/CodeCompliance/Application/Checks/NotUnique/ConstantCheck.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\NotUnique;
 

--- a/src/CodeCompliance/Application/Checks/NotUnique/ConstantCheck.php
+++ b/src/CodeCompliance/Application/Checks/NotUnique/ConstantCheck.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\NotUnique;
 

--- a/src/CodeCompliance/Application/Checks/NotUnique/DatabaseColumnCheck.php
+++ b/src/CodeCompliance/Application/Checks/NotUnique/DatabaseColumnCheck.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Application\Checks\NotUnique;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/src/CodeCompliance/Application/Checks/NotUnique/DatabaseColumnCheck.php
+++ b/src/CodeCompliance/Application/Checks/NotUnique/DatabaseColumnCheck.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\NotUnique;
 

--- a/src/CodeCompliance/Application/Checks/NotUnique/DatabaseColumnCheck.php
+++ b/src/CodeCompliance/Application/Checks/NotUnique/DatabaseColumnCheck.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\NotUnique;
 

--- a/src/CodeCompliance/Application/Checks/NotUnique/DatabaseTableCheck.php
+++ b/src/CodeCompliance/Application/Checks/NotUnique/DatabaseTableCheck.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Application\Checks\NotUnique;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/src/CodeCompliance/Application/Checks/NotUnique/DatabaseTableCheck.php
+++ b/src/CodeCompliance/Application/Checks/NotUnique/DatabaseTableCheck.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\NotUnique;
 

--- a/src/CodeCompliance/Application/Checks/NotUnique/DatabaseTableCheck.php
+++ b/src/CodeCompliance/Application/Checks/NotUnique/DatabaseTableCheck.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\NotUnique;
 

--- a/src/CodeCompliance/Application/Checks/NotUnique/MethodCheck.php
+++ b/src/CodeCompliance/Application/Checks/NotUnique/MethodCheck.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Application\Checks\NotUnique;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/src/CodeCompliance/Application/Checks/NotUnique/MethodCheck.php
+++ b/src/CodeCompliance/Application/Checks/NotUnique/MethodCheck.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\NotUnique;
 

--- a/src/CodeCompliance/Application/Checks/NotUnique/MethodCheck.php
+++ b/src/CodeCompliance/Application/Checks/NotUnique/MethodCheck.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\NotUnique;
 

--- a/src/CodeCompliance/Application/Checks/NotUnique/TransferNameCheck.php
+++ b/src/CodeCompliance/Application/Checks/NotUnique/TransferNameCheck.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Application\Checks\NotUnique;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/src/CodeCompliance/Application/Checks/NotUnique/TransferNameCheck.php
+++ b/src/CodeCompliance/Application/Checks/NotUnique/TransferNameCheck.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\NotUnique;
 

--- a/src/CodeCompliance/Application/Checks/NotUnique/TransferNameCheck.php
+++ b/src/CodeCompliance/Application/Checks/NotUnique/TransferNameCheck.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\NotUnique;
 

--- a/src/CodeCompliance/Application/Checks/NotUnique/TransferPropertyCheck.php
+++ b/src/CodeCompliance/Application/Checks/NotUnique/TransferPropertyCheck.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Application\Checks\NotUnique;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/src/CodeCompliance/Application/Checks/NotUnique/TransferPropertyCheck.php
+++ b/src/CodeCompliance/Application/Checks/NotUnique/TransferPropertyCheck.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\NotUnique;
 

--- a/src/CodeCompliance/Application/Checks/NotUnique/TransferPropertyCheck.php
+++ b/src/CodeCompliance/Application/Checks/NotUnique/TransferPropertyCheck.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\NotUnique;
 

--- a/src/CodeCompliance/Application/Checks/PrivateApi/Extended/ExtendedCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/Extended/ExtendedCheck.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\PrivateApi\Extended;
 

--- a/src/CodeCompliance/Application/Checks/PrivateApi/Extended/ExtendedCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/Extended/ExtendedCheck.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Application\Checks\PrivateApi\Extended;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/src/CodeCompliance/Application/Checks/PrivateApi/Extended/ExtendedCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/Extended/ExtendedCheck.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\PrivateApi\Extended;
 

--- a/src/CodeCompliance/Application/Checks/PrivateApi/MethodOverwritten/MethodIsOverwrittenCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/MethodOverwritten/MethodIsOverwrittenCheck.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\PrivateApi\MethodOverwritten;
 

--- a/src/CodeCompliance/Application/Checks/PrivateApi/MethodOverwritten/MethodIsOverwrittenCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/MethodOverwritten/MethodIsOverwrittenCheck.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Application\Checks\PrivateApi\MethodOverwritten;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/src/CodeCompliance/Application/Checks/PrivateApi/MethodOverwritten/MethodIsOverwrittenCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/MethodOverwritten/MethodIsOverwrittenCheck.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\PrivateApi\MethodOverwritten;
 

--- a/src/CodeCompliance/Application/Checks/PrivateApi/Used/CorePersistenceCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/Used/CorePersistenceCheck.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Application\Checks\PrivateApi\Used;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/src/CodeCompliance/Application/Checks/PrivateApi/Used/CorePersistenceCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/Used/CorePersistenceCheck.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Application/Checks/PrivateApi/Used/CorePersistenceCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/Used/CorePersistenceCheck.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Application/Checks/PrivateApi/Used/DependencyInBusinessModelCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/Used/DependencyInBusinessModelCheck.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Application\Checks\PrivateApi\Used;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/src/CodeCompliance/Application/Checks/PrivateApi/Used/DependencyInBusinessModelCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/Used/DependencyInBusinessModelCheck.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Application/Checks/PrivateApi/Used/DependencyInBusinessModelCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/Used/DependencyInBusinessModelCheck.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Application/Checks/PrivateApi/Used/DependencyProviderCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/Used/DependencyProviderCheck.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Application\Checks\PrivateApi\Used;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/src/CodeCompliance/Application/Checks/PrivateApi/Used/DependencyProviderCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/Used/DependencyProviderCheck.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Application/Checks/PrivateApi/Used/DependencyProviderCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/Used/DependencyProviderCheck.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Application/Checks/PrivateApi/Used/FacadeCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/Used/FacadeCheck.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Application\Checks\PrivateApi\Used;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/src/CodeCompliance/Application/Checks/PrivateApi/Used/FacadeCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/Used/FacadeCheck.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Application/Checks/PrivateApi/Used/FacadeCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/Used/FacadeCheck.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Application/Checks/PrivateApi/Used/InitializedInBusinessModelCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/Used/InitializedInBusinessModelCheck.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Application\Checks\PrivateApi\Used;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/src/CodeCompliance/Application/Checks/PrivateApi/Used/InitializedInBusinessModelCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/Used/InitializedInBusinessModelCheck.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Application/Checks/PrivateApi/Used/InitializedInBusinessModelCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/Used/InitializedInBusinessModelCheck.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Application/Checks/PrivateApi/Used/PersistenceCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/Used/PersistenceCheck.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Application\Checks\PrivateApi\Used;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/src/CodeCompliance/Application/Checks/PrivateApi/Used/PersistenceCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/Used/PersistenceCheck.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Application/Checks/PrivateApi/Used/PersistenceCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/Used/PersistenceCheck.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Application/Checks/PrivateApi/Used/PersistenceInBusinessModelCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/Used/PersistenceInBusinessModelCheck.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Application\Checks\PrivateApi\Used;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/src/CodeCompliance/Application/Checks/PrivateApi/Used/PersistenceInBusinessModelCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/Used/PersistenceInBusinessModelCheck.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Application/Checks/PrivateApi/Used/PersistenceInBusinessModelCheck.php
+++ b/src/CodeCompliance/Application/Checks/PrivateApi/Used/PersistenceInBusinessModelCheck.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Application\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Application/Service/CodeComplianceService.php
+++ b/src/CodeCompliance/Application/Service/CodeComplianceService.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Application\Service;
 

--- a/src/CodeCompliance/Application/Service/CodeComplianceService.php
+++ b/src/CodeCompliance/Application/Service/CodeComplianceService.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Application\Service;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/src/CodeCompliance/Application/Service/CodeComplianceService.php
+++ b/src/CodeCompliance/Application/Service/CodeComplianceService.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Application\Service;
 

--- a/src/CodeCompliance/Application/Service/CodeComplianceServiceInterface.php
+++ b/src/CodeCompliance/Application/Service/CodeComplianceServiceInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Application\Service;
 

--- a/src/CodeCompliance/Application/Service/CodeComplianceServiceInterface.php
+++ b/src/CodeCompliance/Application/Service/CodeComplianceServiceInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Application\Service;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/src/CodeCompliance/Application/Service/CodeComplianceServiceInterface.php
+++ b/src/CodeCompliance/Application/Service/CodeComplianceServiceInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Application\Service;
 

--- a/src/CodeCompliance/Domain/AbstractCodeComplianceCheck.php
+++ b/src/CodeCompliance/Domain/AbstractCodeComplianceCheck.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain;
 

--- a/src/CodeCompliance/Domain/AbstractCodeComplianceCheck.php
+++ b/src/CodeCompliance/Domain/AbstractCodeComplianceCheck.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain;
 

--- a/src/CodeCompliance/Domain/AbstractCodeComplianceCheck.php
+++ b/src/CodeCompliance/Domain/AbstractCodeComplianceCheck.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/src/CodeCompliance/Domain/Checks/Filters/AbstractIgnoreListFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/AbstractIgnoreListFilter.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\Filters;
 
 abstract class AbstractIgnoreListFilter implements FilterInterface

--- a/src/CodeCompliance/Domain/Checks/Filters/AbstractIgnoreListFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/AbstractIgnoreListFilter.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\Filters;
 

--- a/src/CodeCompliance/Domain/Checks/Filters/AbstractIgnoreListFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/AbstractIgnoreListFilter.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\Filters;
 

--- a/src/CodeCompliance/Domain/Checks/Filters/BusinessFactoryFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/BusinessFactoryFilter.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\Filters;
 
 use Codebase\Application\Dto\CodebaseInterface;

--- a/src/CodeCompliance/Domain/Checks/Filters/BusinessFactoryFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/BusinessFactoryFilter.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\Filters;
 

--- a/src/CodeCompliance/Domain/Checks/Filters/BusinessFactoryFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/BusinessFactoryFilter.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\Filters;
 

--- a/src/CodeCompliance/Domain/Checks/Filters/BusinessModelFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/BusinessModelFilter.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\Filters;
 
 class BusinessModelFilter implements FilterInterface

--- a/src/CodeCompliance/Domain/Checks/Filters/BusinessModelFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/BusinessModelFilter.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\Filters;
 

--- a/src/CodeCompliance/Domain/Checks/Filters/BusinessModelFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/BusinessModelFilter.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\Filters;
 

--- a/src/CodeCompliance/Domain/Checks/Filters/CoreClassFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/CoreClassFilter.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\Filters;
 
 use Codebase\Application\Dto\CodebaseInterface;

--- a/src/CodeCompliance/Domain/Checks/Filters/CoreClassFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/CoreClassFilter.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\Filters;
 

--- a/src/CodeCompliance/Domain/Checks/Filters/CoreClassFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/CoreClassFilter.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\Filters;
 

--- a/src/CodeCompliance/Domain/Checks/Filters/CoreExtensionFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/CoreExtensionFilter.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\Filters;
 
 use Codebase\Application\Dto\CodebaseInterface;

--- a/src/CodeCompliance/Domain/Checks/Filters/CoreExtensionFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/CoreExtensionFilter.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\Filters;
 

--- a/src/CodeCompliance/Domain/Checks/Filters/CoreExtensionFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/CoreExtensionFilter.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\Filters;
 

--- a/src/CodeCompliance/Domain/Checks/Filters/FacadeFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/FacadeFilter.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\Filters;
 

--- a/src/CodeCompliance/Domain/Checks/Filters/FacadeFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/FacadeFilter.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\Filters;
 

--- a/src/CodeCompliance/Domain/Checks/Filters/FacadeFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/FacadeFilter.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\Filters;
 
 class FacadeFilter implements FilterInterface

--- a/src/CodeCompliance/Domain/Checks/Filters/FilterInterface.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/FilterInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\Filters;
 

--- a/src/CodeCompliance/Domain/Checks/Filters/FilterInterface.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/FilterInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\Filters;
 

--- a/src/CodeCompliance/Domain/Checks/Filters/FilterInterface.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/FilterInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\Filters;
 
 interface FilterInterface

--- a/src/CodeCompliance/Domain/Checks/Filters/IgnoreListFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/IgnoreListFilter.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\Filters;
 
 use Codebase\Application\Dto\CodebaseInterface;

--- a/src/CodeCompliance/Domain/Checks/Filters/IgnoreListFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/IgnoreListFilter.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\Filters;
 

--- a/src/CodeCompliance/Domain/Checks/Filters/IgnoreListFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/IgnoreListFilter.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\Filters;
 

--- a/src/CodeCompliance/Domain/Checks/Filters/IgnoreListParentFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/IgnoreListParentFilter.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\Filters;
 
 use Codebase\Application\Dto\CodebaseInterface;

--- a/src/CodeCompliance/Domain/Checks/Filters/IgnoreListParentFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/IgnoreListParentFilter.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\Filters;
 

--- a/src/CodeCompliance/Domain/Checks/Filters/IgnoreListParentFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/IgnoreListParentFilter.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\Filters;
 

--- a/src/CodeCompliance/Domain/Checks/Filters/PersistenceFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/PersistenceFilter.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\Filters;
 
 use Codebase\Application\Dto\CodebaseInterface;

--- a/src/CodeCompliance/Domain/Checks/Filters/PersistenceFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/PersistenceFilter.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\Filters;
 

--- a/src/CodeCompliance/Domain/Checks/Filters/PersistenceFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/PersistenceFilter.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\Filters;
 

--- a/src/CodeCompliance/Domain/Checks/Filters/PluginFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/PluginFilter.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\Filters;
 
 use Codebase\Application\Dto\CodebaseInterface;

--- a/src/CodeCompliance/Domain/Checks/Filters/PluginFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/PluginFilter.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\Filters;
 

--- a/src/CodeCompliance/Domain/Checks/Filters/PluginFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/PluginFilter.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\Filters;
 

--- a/src/CodeCompliance/Domain/Checks/Filters/PrivateApiFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/PrivateApiFilter.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\Filters;
 

--- a/src/CodeCompliance/Domain/Checks/Filters/PrivateApiFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/PrivateApiFilter.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\Filters;
 

--- a/src/CodeCompliance/Domain/Checks/Filters/PrivateApiFilter.php
+++ b/src/CodeCompliance/Domain/Checks/Filters/PrivateApiFilter.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\Filters;
 
 class PrivateApiFilter implements FilterInterface

--- a/src/CodeCompliance/Domain/Checks/NotUnique/Constant.php
+++ b/src/CodeCompliance/Domain/Checks/NotUnique/Constant.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\NotUnique;
 
 use CodeCompliance\Domain\AbstractCodeComplianceCheck;
@@ -57,7 +59,7 @@ class Constant extends AbstractCodeComplianceCheck
                         strtoupper((string)reset($projectPrefixes)),
                         $nameConstant,
                     );
-                    $violations[] = new Violation(new Id(), $guideline, $this->getName());
+                    $violations[] = new Violation((string)(new Id()), $guideline, $this->getName());
                 }
             }
         }

--- a/src/CodeCompliance/Domain/Checks/NotUnique/Constant.php
+++ b/src/CodeCompliance/Domain/Checks/NotUnique/Constant.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\NotUnique;
 

--- a/src/CodeCompliance/Domain/Checks/NotUnique/Constant.php
+++ b/src/CodeCompliance/Domain/Checks/NotUnique/Constant.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\NotUnique;
 

--- a/src/CodeCompliance/Domain/Checks/NotUnique/DatabaseColumn.php
+++ b/src/CodeCompliance/Domain/Checks/NotUnique/DatabaseColumn.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\NotUnique;
 
 use CodeCompliance\Domain\AbstractCodeComplianceCheck;
@@ -73,7 +75,7 @@ class DatabaseColumn extends AbstractCodeComplianceCheck
                         strtolower((string)reset($projectPrefixes)),
                         $columnWithoutPrefix,
                     );
-                    $violations[] = new Violation(new Id(), $guideline, $this->getName());
+                    $violations[] = new Violation((string)(new Id()), $guideline, $this->getName());
                 }
             }
         }

--- a/src/CodeCompliance/Domain/Checks/NotUnique/DatabaseColumn.php
+++ b/src/CodeCompliance/Domain/Checks/NotUnique/DatabaseColumn.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\NotUnique;
 

--- a/src/CodeCompliance/Domain/Checks/NotUnique/DatabaseColumn.php
+++ b/src/CodeCompliance/Domain/Checks/NotUnique/DatabaseColumn.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\NotUnique;
 

--- a/src/CodeCompliance/Domain/Checks/NotUnique/DatabaseTable.php
+++ b/src/CodeCompliance/Domain/Checks/NotUnique/DatabaseTable.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\NotUnique;
 
 use CodeCompliance\Domain\AbstractCodeComplianceCheck;
@@ -55,7 +57,7 @@ class DatabaseTable extends AbstractCodeComplianceCheck
                     strtolower((string)reset($projectPrefixes)),
                     $schema->getName(),
                 );
-                $violations[] = new Violation(new Id(), $guideline, $this->getName());
+                $violations[] = new Violation((string)(new Id()), $guideline, $this->getName());
             }
         }
 

--- a/src/CodeCompliance/Domain/Checks/NotUnique/DatabaseTable.php
+++ b/src/CodeCompliance/Domain/Checks/NotUnique/DatabaseTable.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\NotUnique;
 

--- a/src/CodeCompliance/Domain/Checks/NotUnique/DatabaseTable.php
+++ b/src/CodeCompliance/Domain/Checks/NotUnique/DatabaseTable.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\NotUnique;
 

--- a/src/CodeCompliance/Domain/Checks/NotUnique/Method.php
+++ b/src/CodeCompliance/Domain/Checks/NotUnique/Method.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\NotUnique;
 
 use CodeCompliance\Domain\AbstractCodeComplianceCheck;
@@ -77,7 +79,7 @@ class Method extends AbstractCodeComplianceCheck
                         $projectMethod->getName(),
                         lcfirst(implode('', $methodParts)),
                     );
-                    $violations[] = new Violation(new Id(), $guideline, $this->getName());
+                    $violations[] = new Violation((string)(new Id()), $guideline, $this->getName());
                 }
             }
         }

--- a/src/CodeCompliance/Domain/Checks/NotUnique/Method.php
+++ b/src/CodeCompliance/Domain/Checks/NotUnique/Method.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\NotUnique;
 

--- a/src/CodeCompliance/Domain/Checks/NotUnique/Method.php
+++ b/src/CodeCompliance/Domain/Checks/NotUnique/Method.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\NotUnique;
 

--- a/src/CodeCompliance/Domain/Checks/NotUnique/TransferName.php
+++ b/src/CodeCompliance/Domain/Checks/NotUnique/TransferName.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\NotUnique;
 

--- a/src/CodeCompliance/Domain/Checks/NotUnique/TransferName.php
+++ b/src/CodeCompliance/Domain/Checks/NotUnique/TransferName.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\NotUnique;
 
 use CodeCompliance\Domain\AbstractCodeComplianceCheck;
@@ -55,7 +57,7 @@ class TransferName extends AbstractCodeComplianceCheck
                     reset($projectPrefixes),
                     $transfer->getName(),
                 );
-                $violations[] = new Violation(new Id(), $guideline, $this->getName());
+                $violations[] = new Violation((string)(new Id()), $guideline, $this->getName());
             }
         }
 

--- a/src/CodeCompliance/Domain/Checks/NotUnique/TransferName.php
+++ b/src/CodeCompliance/Domain/Checks/NotUnique/TransferName.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\NotUnique;
 

--- a/src/CodeCompliance/Domain/Checks/NotUnique/TransferProperty.php
+++ b/src/CodeCompliance/Domain/Checks/NotUnique/TransferProperty.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\NotUnique;
 
 use CodeCompliance\Domain\AbstractCodeComplianceCheck;
@@ -75,7 +77,7 @@ class TransferProperty extends AbstractCodeComplianceCheck
                         strtolower((string)reset($projectPrefixes)),
                         ucfirst($propertyWithoutPrefix),
                     );
-                    $violations[] = new Violation(new Id(), $guideline, $this->getName());
+                    $violations[] = new Violation((string)(new Id()), $guideline, $this->getName());
                 }
             }
         }

--- a/src/CodeCompliance/Domain/Checks/NotUnique/TransferProperty.php
+++ b/src/CodeCompliance/Domain/Checks/NotUnique/TransferProperty.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\NotUnique;
 

--- a/src/CodeCompliance/Domain/Checks/NotUnique/TransferProperty.php
+++ b/src/CodeCompliance/Domain/Checks/NotUnique/TransferProperty.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\NotUnique;
 

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Extended/Extended.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Extended/Extended.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\PrivateApi\Extended;
 
 use CodeCompliance\Domain\AbstractCodeComplianceCheck;
@@ -54,7 +56,7 @@ class Extended extends AbstractCodeComplianceCheck
             }
 
             $guideline = sprintf($this->getGuideline(), $coreParent->getClassName(), $source->getClassName());
-            $violations[] = new Violation(new Id(), $guideline, $this->getName());
+            $violations[] = new Violation((string)(new Id()), $guideline, $this->getName());
         }
 
         return $violations;

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Extended/Extended.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Extended/Extended.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\PrivateApi\Extended;
 

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Extended/Extended.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Extended/Extended.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\PrivateApi\Extended;
 

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/MethodOverwritten/MethodIsOverwritten.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/MethodOverwritten/MethodIsOverwritten.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\PrivateApi\MethodOverwritten;
 

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/MethodOverwritten/MethodIsOverwritten.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/MethodOverwritten/MethodIsOverwritten.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\PrivateApi\MethodOverwritten;
 

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/MethodOverwritten/MethodIsOverwritten.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/MethodOverwritten/MethodIsOverwritten.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\PrivateApi\MethodOverwritten;
 
 use Codebase\Application\Dto\CodebaseInterface;
@@ -59,7 +61,7 @@ class MethodIsOverwritten extends AbstractCodeComplianceCheck
                 }
                 foreach ($this->filterNotUniqueMethods($filteredSource) as $filteredMethod) {
                     $guideline = sprintf($this->getGuideline(), $filteredSource->getCoreParent()->getClassName(), $filteredMethod->getName(), $filteredSource->getClassName());
-                    $violations[] = new Violation(new Id(), $guideline, $this->getName());
+                    $violations[] = new Violation((string)(new Id()), $guideline, $this->getName());
                 }
             }
         }

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/AbstractUsedCodeComplianceCheck.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/AbstractUsedCodeComplianceCheck.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/AbstractUsedCodeComplianceCheck.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/AbstractUsedCodeComplianceCheck.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/AbstractUsedCodeComplianceCheck.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/AbstractUsedCodeComplianceCheck.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\PrivateApi\Used;
 
 use CodeCompliance\Domain\AbstractCodeComplianceCheck;

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/CorePersistence.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/CorePersistence.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/CorePersistence.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/CorePersistence.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\PrivateApi\Used;
 
 use CodeCompliance\Domain\Checks\Filters\IgnoreListParentFilter;
@@ -66,7 +68,7 @@ class CorePersistence extends AbstractUsedCodeComplianceCheck
                     )
                 ) {
                     $guideline = sprintf($this->getGuideline(), $source->getClassName(), $methodName);
-                    $violations[] = new Violation(new Id(), $guideline, $this->getName());
+                    $violations[] = new Violation((string)(new Id()), $guideline, $this->getName());
                 }
             }
         }

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/CorePersistence.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/CorePersistence.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/DependencyInBusinessModel.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/DependencyInBusinessModel.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/DependencyInBusinessModel.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/DependencyInBusinessModel.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/DependencyInBusinessModel.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/DependencyInBusinessModel.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\PrivateApi\Used;
 
 use CodeCompliance\Domain\Checks\Filters\BusinessModelFilter;
@@ -69,7 +71,7 @@ class DependencyInBusinessModel extends AbstractUsedCodeComplianceCheck
 
             foreach ($dependencyCoreSources as $class) {
                 $guideline = sprintf($this->getGuideline(), $class->getClassName(), $source->getClassName());
-                $violations[] = new Violation(new Id(), $guideline, $this->getName());
+                $violations[] = new Violation((string)(new Id()), $guideline, $this->getName());
             }
         }
 

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/DependencyProvider.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/DependencyProvider.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/DependencyProvider.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/DependencyProvider.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/DependencyProvider.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/DependencyProvider.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\PrivateApi\Used;
 
 use CodeCompliance\Domain\Checks\Filters\BusinessFactoryFilter;
@@ -61,7 +63,7 @@ class DependencyProvider extends AbstractUsedCodeComplianceCheck
 
                 if (!$constantName) {
                     $guideline = sprintf('Please create constant from %s in %s', $argumentString, $source->getClassName());
-                    $violations[] = new Violation(new Id(), $guideline, $this->getName());
+                    $violations[] = new Violation((string)(new Id()), $guideline, $this->getName());
 
                     continue;
                 }
@@ -70,7 +72,7 @@ class DependencyProvider extends AbstractUsedCodeComplianceCheck
 
                 if (!$constantClassName || $constantClassName === 'static' || $constantClassName === 'self') {
                     $guideline = sprintf('Please use constant from DependencyProvider instead of %s in %s', $argumentString, $source->getClassName());
-                    $violations[] = new Violation(new Id(), $guideline, $this->getName());
+                    $violations[] = new Violation((string)(new Id()), $guideline, $this->getName());
 
                     continue;
                 }
@@ -89,7 +91,7 @@ class DependencyProvider extends AbstractUsedCodeComplianceCheck
 
                 if ($this->hasCoreNamespace($this->getCodebaseSourceDto()->getCoreNamespaces(), $constantClassNamespace)) {
                     $guideline = sprintf($this->getGuideline(), $constantClassName, $constantName, $source->getClassName());
-                    $violations[] = new Violation(new Id(), $guideline, $this->getName());
+                    $violations[] = new Violation((string)(new Id()), $guideline, $this->getName());
 
                     continue;
                 }
@@ -102,7 +104,7 @@ class DependencyProvider extends AbstractUsedCodeComplianceCheck
 
                     if ($this->isContainsConstantByName($parentConstants, $constantName)) {
                         $guideline = sprintf($this->getGuideline(), $constantClassName, $constantName, $source->getClassName());
-                        $violations[] = new Violation(new Id(), $guideline, $this->getName());
+                        $violations[] = new Violation((string)(new Id()), $guideline, $this->getName());
                     }
                 }
             }

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/Facade.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/Facade.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/Facade.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/Facade.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/Facade.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/Facade.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\PrivateApi\Used;
 
 use CodeCompliance\Domain\Checks\Filters\FacadeFilter;
@@ -65,7 +67,7 @@ class Facade extends AbstractUsedCodeComplianceCheck
                 $classDocComment = $source->getReflection()->getDocComment();
                 if (!$classDocComment) {
                     $message = sprintf(static::DOC_COMMENT_MESSAGE, $source->getReflection()->getName());
-                    $violations[] = new Violation(new Id(), $message, $this->getName());
+                    $violations[] = new Violation((string)(new Id()), $message, $this->getName());
 
                     continue;
                 }
@@ -77,7 +79,7 @@ class Facade extends AbstractUsedCodeComplianceCheck
 
                 if (!$namespace) {
                     $message = sprintf(static::DOC_COMMENT_MESSAGE, '$this->' . $privateApiAnnotation . '() in' . $source->getClassName());
-                    $violations[] = new Violation(new Id(), $message, $this->getName());
+                    $violations[] = new Violation((string)(new Id()), $message, $this->getName());
 
                     continue;
                 }
@@ -99,7 +101,7 @@ class Facade extends AbstractUsedCodeComplianceCheck
                     );
                     if ($hasCoreNamespace) {
                         $guideline = sprintf($this->getGuideline(), $usedMethodName, $source->getClassName());
-                        $violations[] = new Violation(new Id(), $guideline, $this->getName());
+                        $violations[] = new Violation((string)(new Id()), $guideline, $this->getName());
                     }
                 }
             }

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/ObjectIsInitializedInBusinessModel.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/ObjectIsInitializedInBusinessModel.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/ObjectIsInitializedInBusinessModel.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/ObjectIsInitializedInBusinessModel.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/ObjectIsInitializedInBusinessModel.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/ObjectIsInitializedInBusinessModel.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\PrivateApi\Used;
 
 use CodeCompliance\Domain\Checks\Filters\BusinessModelFilter;
@@ -63,7 +65,7 @@ class ObjectIsInitializedInBusinessModel extends AbstractUsedCodeComplianceCheck
 
             foreach ($createdNamespaces as $createdNamespace) {
                 $guideline = sprintf($this->getGuideline(), $createdNamespace, $source->getClassName());
-                $violations[] = new Violation(new Id(), $guideline, $this->getName());
+                $violations[] = new Violation((string)(new Id()), $guideline, $this->getName());
             }
         }
 

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/Persistence.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/Persistence.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/Persistence.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/Persistence.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\PrivateApi\Used;
 
 use CodeCompliance\Domain\Checks\Filters\PersistenceFilter;
@@ -63,7 +65,7 @@ class Persistence extends AbstractUsedCodeComplianceCheck
                 $classDocComment = $source->getReflection()->getDocComment();
                 if (!$classDocComment) {
                     $message = sprintf(static::DOC_COMMENT_MESSAGE, $source->getReflection()->getName());
-                    $violations[] = new Violation(new Id(), $message, $this->getName());
+                    $violations[] = new Violation((string)(new Id()), $message, $this->getName());
 
                     continue;
                 }
@@ -71,7 +73,7 @@ class Persistence extends AbstractUsedCodeComplianceCheck
                 $factoryNamespace = $this->getReturnNamespaceByMethodFromDocComment($classDocComment, $methodToCheck);
                 if (!$factoryNamespace) {
                     $message = sprintf(static::DOC_COMMENT_MESSAGE, '$this->getFactory() in ' . $source->getClassName());
-                    $violations[] = new Violation(new Id(), $message, $this->getName());
+                    $violations[] = new Violation((string)(new Id()), $message, $this->getName());
 
                     continue;
                 }
@@ -91,7 +93,7 @@ class Persistence extends AbstractUsedCodeComplianceCheck
 
                     if ($hasCoreNamespace) {
                         $guideline = sprintf($this->getGuideline(), $usedMethodName, $source->getClassName());
-                        $violations[] = new Violation(new Id(), $guideline, $this->getName());
+                        $violations[] = new Violation((string)(new Id()), $guideline, $this->getName());
                     }
                 }
             }

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/Persistence.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/Persistence.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/PersistenceInBusinessModel.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/PersistenceInBusinessModel.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/PersistenceInBusinessModel.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/PersistenceInBusinessModel.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Checks\PrivateApi\Used;
 
 use CodeCompliance\Domain\Checks\Filters\BusinessModelFilter;
@@ -88,7 +90,7 @@ class PersistenceInBusinessModel extends AbstractUsedCodeComplianceCheck
                         )
                     ) {
                         $guideline = sprintf($this->getGuideline(), $methodReflection->getDeclaringClass()->getName(), $methodName, $source->getClassName());
-                        $violations[] = new Violation(new Id(), $guideline, $this->getName());
+                        $violations[] = new Violation((string)(new Id()), $guideline, $this->getName());
                     }
                 }
             }

--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/PersistenceInBusinessModel.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/PersistenceInBusinessModel.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Checks\PrivateApi\Used;
 

--- a/src/CodeCompliance/Domain/CodeComplianceCheckInterface.php
+++ b/src/CodeCompliance/Domain/CodeComplianceCheckInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain;
 
 interface CodeComplianceCheckInterface

--- a/src/CodeCompliance/Domain/CodeComplianceCheckInterface.php
+++ b/src/CodeCompliance/Domain/CodeComplianceCheckInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain;
 

--- a/src/CodeCompliance/Domain/CodeComplianceCheckInterface.php
+++ b/src/CodeCompliance/Domain/CodeComplianceCheckInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain;
 

--- a/src/CodeCompliance/Domain/Entity/Package.php
+++ b/src/CodeCompliance/Domain/Entity/Package.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Entity;
 

--- a/src/CodeCompliance/Domain/Entity/Package.php
+++ b/src/CodeCompliance/Domain/Entity/Package.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Entity;
 

--- a/src/CodeCompliance/Domain/Entity/Package.php
+++ b/src/CodeCompliance/Domain/Entity/Package.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Entity;
 
 use SprykerSdk\SdkContracts\Violation\PackageViolationReportInterface;

--- a/src/CodeCompliance/Domain/Entity/PackageFileViolation.php
+++ b/src/CodeCompliance/Domain/Entity/PackageFileViolation.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Entity;
 
 use SprykerSdk\SdkContracts\Violation\ViolationFixInterface;

--- a/src/CodeCompliance/Domain/Entity/PackageFileViolation.php
+++ b/src/CodeCompliance/Domain/Entity/PackageFileViolation.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Entity;
 

--- a/src/CodeCompliance/Domain/Entity/PackageFileViolation.php
+++ b/src/CodeCompliance/Domain/Entity/PackageFileViolation.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Entity;
 

--- a/src/CodeCompliance/Domain/Entity/Report.php
+++ b/src/CodeCompliance/Domain/Entity/Report.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Entity;
 

--- a/src/CodeCompliance/Domain/Entity/Report.php
+++ b/src/CodeCompliance/Domain/Entity/Report.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Entity;
 

--- a/src/CodeCompliance/Domain/Entity/Report.php
+++ b/src/CodeCompliance/Domain/Entity/Report.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Entity;
 
 use SprykerSdk\SdkContracts\Violation\PackageViolationReportInterface;

--- a/src/CodeCompliance/Domain/Entity/Violation.php
+++ b/src/CodeCompliance/Domain/Entity/Violation.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Entity;
 
 use SprykerSdk\SdkContracts\Violation\ViolationFixInterface;

--- a/src/CodeCompliance/Domain/Entity/Violation.php
+++ b/src/CodeCompliance/Domain/Entity/Violation.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Entity;
 

--- a/src/CodeCompliance/Domain/Entity/Violation.php
+++ b/src/CodeCompliance/Domain/Entity/Violation.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Entity;
 

--- a/src/CodeCompliance/Domain/Service/CodeBaseServiceInterface.php
+++ b/src/CodeCompliance/Domain/Service/CodeBaseServiceInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Service;
 

--- a/src/CodeCompliance/Domain/Service/CodeBaseServiceInterface.php
+++ b/src/CodeCompliance/Domain/Service/CodeBaseServiceInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Service;
 
 use Codebase\Application\Dto\ClassCodebaseDto;

--- a/src/CodeCompliance/Domain/Service/CodeBaseServiceInterface.php
+++ b/src/CodeCompliance/Domain/Service/CodeBaseServiceInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Service;
 

--- a/src/CodeCompliance/Domain/Service/FilterService.php
+++ b/src/CodeCompliance/Domain/Service/FilterService.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Domain\Service;
 
 class FilterService

--- a/src/CodeCompliance/Domain/Service/FilterService.php
+++ b/src/CodeCompliance/Domain/Service/FilterService.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Service;
 

--- a/src/CodeCompliance/Domain/Service/FilterService.php
+++ b/src/CodeCompliance/Domain/Service/FilterService.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Domain\Service;
 

--- a/src/CodeCompliance/Infrastructure/Service/CodeBaseService.php
+++ b/src/CodeCompliance/Infrastructure/Service/CodeBaseService.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeCompliance\Infrastructure\Service;
 
 use Codebase\Application\Dto\ClassCodebaseDto;

--- a/src/CodeCompliance/Infrastructure/Service/CodeBaseService.php
+++ b/src/CodeCompliance/Infrastructure/Service/CodeBaseService.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeCompliance\Infrastructure\Service;
 

--- a/src/CodeCompliance/Infrastructure/Service/CodeBaseService.php
+++ b/src/CodeCompliance/Infrastructure/Service/CodeBaseService.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeCompliance\Infrastructure\Service;
 

--- a/src/Codebase/Application/Dto/AbstractCodebaseDto.php
+++ b/src/Codebase/Application/Dto/AbstractCodebaseDto.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Application\Dto;
 

--- a/src/Codebase/Application/Dto/AbstractCodebaseDto.php
+++ b/src/Codebase/Application/Dto/AbstractCodebaseDto.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Application\Dto;
 
 class AbstractCodebaseDto implements CodebaseInterface

--- a/src/Codebase/Application/Dto/AbstractCodebaseDto.php
+++ b/src/Codebase/Application/Dto/AbstractCodebaseDto.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Application\Dto;
 

--- a/src/Codebase/Application/Dto/ClassCodebaseDto.php
+++ b/src/Codebase/Application/Dto/ClassCodebaseDto.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Application\Dto;
 

--- a/src/Codebase/Application/Dto/ClassCodebaseDto.php
+++ b/src/Codebase/Application/Dto/ClassCodebaseDto.php
@@ -27,12 +27,12 @@ class ClassCodebaseDto extends AbstractCodebaseDto
     protected array $constants = [];
 
     /**
-     * @var array<string>
+     * @var array<\ReflectionMethod>
      */
     protected array $methods = [];
 
     /**
-     * @var array<string>
+     * @var array<\ReflectionClass>
      */
     protected array $traits = [];
 
@@ -77,7 +77,7 @@ class ClassCodebaseDto extends AbstractCodebaseDto
     }
 
     /**
-     * @return array<string>
+     * @return array<\ReflectionMethod>
      */
     public function getMethods(): array
     {
@@ -85,7 +85,7 @@ class ClassCodebaseDto extends AbstractCodebaseDto
     }
 
     /**
-     * @param array<string> $methods
+     * @param array<\ReflectionMethod> $methods
      *
      * @return $this
      */
@@ -97,7 +97,7 @@ class ClassCodebaseDto extends AbstractCodebaseDto
     }
 
     /**
-     * @return array<string>
+     * @return array<\ReflectionClass>
      */
     public function getTraits(): array
     {
@@ -105,7 +105,7 @@ class ClassCodebaseDto extends AbstractCodebaseDto
     }
 
     /**
-     * @param array<string> $traits
+     * @param array<\ReflectionClass> $traits
      *
      * @return $this
      */

--- a/src/Codebase/Application/Dto/ClassCodebaseDto.php
+++ b/src/Codebase/Application/Dto/ClassCodebaseDto.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Application\Dto;
 

--- a/src/Codebase/Application/Dto/ClassCodebaseDto.php
+++ b/src/Codebase/Application/Dto/ClassCodebaseDto.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Application\Dto;
 
 use ReflectionClass;

--- a/src/Codebase/Application/Dto/CodeBaseRequestDto.php
+++ b/src/Codebase/Application/Dto/CodeBaseRequestDto.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Application\Dto;
 

--- a/src/Codebase/Application/Dto/CodeBaseRequestDto.php
+++ b/src/Codebase/Application/Dto/CodeBaseRequestDto.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Application\Dto;
 
 class CodeBaseRequestDto

--- a/src/Codebase/Application/Dto/CodeBaseRequestDto.php
+++ b/src/Codebase/Application/Dto/CodeBaseRequestDto.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Application\Dto;
 

--- a/src/Codebase/Application/Dto/CodebaseInterface.php
+++ b/src/Codebase/Application/Dto/CodebaseInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Application\Dto;
 
 interface CodebaseInterface

--- a/src/Codebase/Application/Dto/CodebaseInterface.php
+++ b/src/Codebase/Application/Dto/CodebaseInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Application\Dto;
 

--- a/src/Codebase/Application/Dto/CodebaseInterface.php
+++ b/src/Codebase/Application/Dto/CodebaseInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Application\Dto;
 

--- a/src/Codebase/Application/Dto/CodebaseSourceDto.php
+++ b/src/Codebase/Application/Dto/CodebaseSourceDto.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Application\Dto;
 

--- a/src/Codebase/Application/Dto/CodebaseSourceDto.php
+++ b/src/Codebase/Application/Dto/CodebaseSourceDto.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Application\Dto;
 
 class CodebaseSourceDto

--- a/src/Codebase/Application/Dto/CodebaseSourceDto.php
+++ b/src/Codebase/Application/Dto/CodebaseSourceDto.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Application\Dto;
 

--- a/src/Codebase/Application/Dto/ConfigurationResponseDto.php
+++ b/src/Codebase/Application/Dto/ConfigurationResponseDto.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Application\Dto;
 
 class ConfigurationResponseDto

--- a/src/Codebase/Application/Dto/ConfigurationResponseDto.php
+++ b/src/Codebase/Application/Dto/ConfigurationResponseDto.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Application\Dto;
 

--- a/src/Codebase/Application/Dto/ConfigurationResponseDto.php
+++ b/src/Codebase/Application/Dto/ConfigurationResponseDto.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Application\Dto;
 

--- a/src/Codebase/Application/Dto/ModuleDto.php
+++ b/src/Codebase/Application/Dto/ModuleDto.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Application\Dto;
 

--- a/src/Codebase/Application/Dto/ModuleDto.php
+++ b/src/Codebase/Application/Dto/ModuleDto.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Application\Dto;
 
 class ModuleDto

--- a/src/Codebase/Application/Dto/ModuleDto.php
+++ b/src/Codebase/Application/Dto/ModuleDto.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Application\Dto;
 

--- a/src/Codebase/Application/Dto/SourceParserRequestDto.php
+++ b/src/Codebase/Application/Dto/SourceParserRequestDto.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Application\Dto;
 
 class SourceParserRequestDto

--- a/src/Codebase/Application/Dto/SourceParserRequestDto.php
+++ b/src/Codebase/Application/Dto/SourceParserRequestDto.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Application\Dto;
 

--- a/src/Codebase/Application/Dto/SourceParserRequestDto.php
+++ b/src/Codebase/Application/Dto/SourceParserRequestDto.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Application\Dto;
 

--- a/src/Codebase/Application/Dto/XmlDto.php
+++ b/src/Codebase/Application/Dto/XmlDto.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Application\Dto;
 
 class XmlDto implements CodebaseInterface

--- a/src/Codebase/Application/Dto/XmlDto.php
+++ b/src/Codebase/Application/Dto/XmlDto.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Application\Dto;
 

--- a/src/Codebase/Application/Dto/XmlDto.php
+++ b/src/Codebase/Application/Dto/XmlDto.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Application\Dto;
 

--- a/src/Codebase/Application/Service/CodebaseServiceInterface.php
+++ b/src/Codebase/Application/Service/CodebaseServiceInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Application\Service;
 

--- a/src/Codebase/Application/Service/CodebaseServiceInterface.php
+++ b/src/Codebase/Application/Service/CodebaseServiceInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Application\Service;
 

--- a/src/Codebase/Application/Service/CodebaseServiceInterface.php
+++ b/src/Codebase/Application/Service/CodebaseServiceInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Application\Service;
 
 use Codebase\Application\Dto\CodeBaseRequestDto;

--- a/src/Codebase/Infrastructure/CodeBaseReader/CodeBaseReader.php
+++ b/src/Codebase/Infrastructure/CodeBaseReader/CodeBaseReader.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\CodeBaseReader;
 
 use Codebase\Application\Dto\CodeBaseRequestDto;

--- a/src/Codebase/Infrastructure/CodeBaseReader/CodeBaseReader.php
+++ b/src/Codebase/Infrastructure/CodeBaseReader/CodeBaseReader.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\CodeBaseReader;
 

--- a/src/Codebase/Infrastructure/CodeBaseReader/CodeBaseReader.php
+++ b/src/Codebase/Infrastructure/CodeBaseReader/CodeBaseReader.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\CodeBaseReader;
 

--- a/src/Codebase/Infrastructure/CodeBaseReader/CodeBaseReaderInterface.php
+++ b/src/Codebase/Infrastructure/CodeBaseReader/CodeBaseReaderInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\CodeBaseReader;
 
 use Codebase\Application\Dto\CodeBaseRequestDto;

--- a/src/Codebase/Infrastructure/CodeBaseReader/CodeBaseReaderInterface.php
+++ b/src/Codebase/Infrastructure/CodeBaseReader/CodeBaseReaderInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\CodeBaseReader;
 

--- a/src/Codebase/Infrastructure/CodeBaseReader/CodeBaseReaderInterface.php
+++ b/src/Codebase/Infrastructure/CodeBaseReader/CodeBaseReaderInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\CodeBaseReader;
 

--- a/src/Codebase/Infrastructure/CodeBaseReader/Mapper/ModuleOptionMapper.php
+++ b/src/Codebase/Infrastructure/CodeBaseReader/Mapper/ModuleOptionMapper.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\CodeBaseReader\Mapper;
 

--- a/src/Codebase/Infrastructure/CodeBaseReader/Mapper/ModuleOptionMapper.php
+++ b/src/Codebase/Infrastructure/CodeBaseReader/Mapper/ModuleOptionMapper.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\CodeBaseReader\Mapper;
 
 use Codebase\Application\Dto\ModuleDto;

--- a/src/Codebase/Infrastructure/CodeBaseReader/Mapper/ModuleOptionMapper.php
+++ b/src/Codebase/Infrastructure/CodeBaseReader/Mapper/ModuleOptionMapper.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\CodeBaseReader\Mapper;
 

--- a/src/Codebase/Infrastructure/CodeBaseReader/Mapper/ModuleOptionMapperInterface.php
+++ b/src/Codebase/Infrastructure/CodeBaseReader/Mapper/ModuleOptionMapperInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\CodeBaseReader\Mapper;
 

--- a/src/Codebase/Infrastructure/CodeBaseReader/Mapper/ModuleOptionMapperInterface.php
+++ b/src/Codebase/Infrastructure/CodeBaseReader/Mapper/ModuleOptionMapperInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\CodeBaseReader\Mapper;
 
 interface ModuleOptionMapperInterface

--- a/src/Codebase/Infrastructure/CodeBaseReader/Mapper/ModuleOptionMapperInterface.php
+++ b/src/Codebase/Infrastructure/CodeBaseReader/Mapper/ModuleOptionMapperInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\CodeBaseReader\Mapper;
 

--- a/src/Codebase/Infrastructure/CodeBaseReader/Mapper/SourceParserRequestMapper.php
+++ b/src/Codebase/Infrastructure/CodeBaseReader/Mapper/SourceParserRequestMapper.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\CodeBaseReader\Mapper;
 

--- a/src/Codebase/Infrastructure/CodeBaseReader/Mapper/SourceParserRequestMapper.php
+++ b/src/Codebase/Infrastructure/CodeBaseReader/Mapper/SourceParserRequestMapper.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\CodeBaseReader\Mapper;
 

--- a/src/Codebase/Infrastructure/CodeBaseReader/Mapper/SourceParserRequestMapperInterface.php
+++ b/src/Codebase/Infrastructure/CodeBaseReader/Mapper/SourceParserRequestMapperInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\CodeBaseReader\Mapper;
 

--- a/src/Codebase/Infrastructure/CodeBaseReader/Mapper/SourceParserRequestMapperInterface.php
+++ b/src/Codebase/Infrastructure/CodeBaseReader/Mapper/SourceParserRequestMapperInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\CodeBaseReader\Mapper;
 

--- a/src/Codebase/Infrastructure/CodeBaseReader/SourceParserRequestMapper.php
+++ b/src/Codebase/Infrastructure/CodeBaseReader/SourceParserRequestMapper.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\CodeBaseReader;
 
 use Codebase\Application\Dto\CodeBaseRequestDto;

--- a/src/Codebase/Infrastructure/CodeBaseReader/SourceParserRequestMapperInterface.php
+++ b/src/Codebase/Infrastructure/CodeBaseReader/SourceParserRequestMapperInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\CodeBaseReader;
 
 use Codebase\Application\Dto\CodeBaseRequestDto;

--- a/src/Codebase/Infrastructure/Dependency/Finder/CodebaseToFinderBridge.php
+++ b/src/Codebase/Infrastructure/Dependency/Finder/CodebaseToFinderBridge.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\Dependency\Finder;
 

--- a/src/Codebase/Infrastructure/Dependency/Finder/CodebaseToFinderBridge.php
+++ b/src/Codebase/Infrastructure/Dependency/Finder/CodebaseToFinderBridge.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\Dependency\Finder;
 

--- a/src/Codebase/Infrastructure/Dependency/Finder/CodebaseToFinderBridge.php
+++ b/src/Codebase/Infrastructure/Dependency/Finder/CodebaseToFinderBridge.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\Dependency\Finder;
 
 use Symfony\Component\Finder\Finder;

--- a/src/Codebase/Infrastructure/Dependency/Finder/CodebaseToFinderInterface.php
+++ b/src/Codebase/Infrastructure/Dependency/Finder/CodebaseToFinderInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\Dependency\Finder;
 

--- a/src/Codebase/Infrastructure/Dependency/Finder/CodebaseToFinderInterface.php
+++ b/src/Codebase/Infrastructure/Dependency/Finder/CodebaseToFinderInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\Dependency\Finder;
 

--- a/src/Codebase/Infrastructure/Dependency/Finder/CodebaseToFinderInterface.php
+++ b/src/Codebase/Infrastructure/Dependency/Finder/CodebaseToFinderInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\Dependency\Finder;
 
 use Symfony\Component\Finder\Finder;

--- a/src/Codebase/Infrastructure/Dependency/Parser/CodebaseToParserBridge.php
+++ b/src/Codebase/Infrastructure/Dependency/Parser/CodebaseToParserBridge.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\Dependency\Parser;
 
 use PhpParser\ParserFactory;

--- a/src/Codebase/Infrastructure/Dependency/Parser/CodebaseToParserBridge.php
+++ b/src/Codebase/Infrastructure/Dependency/Parser/CodebaseToParserBridge.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\Dependency\Parser;
 

--- a/src/Codebase/Infrastructure/Dependency/Parser/CodebaseToParserBridge.php
+++ b/src/Codebase/Infrastructure/Dependency/Parser/CodebaseToParserBridge.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\Dependency\Parser;
 

--- a/src/Codebase/Infrastructure/Dependency/Parser/CodebaseToParserInterface.php
+++ b/src/Codebase/Infrastructure/Dependency/Parser/CodebaseToParserInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\Dependency\Parser;
 
 interface CodebaseToParserInterface

--- a/src/Codebase/Infrastructure/Dependency/Parser/CodebaseToParserInterface.php
+++ b/src/Codebase/Infrastructure/Dependency/Parser/CodebaseToParserInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\Dependency\Parser;
 

--- a/src/Codebase/Infrastructure/Dependency/Parser/CodebaseToParserInterface.php
+++ b/src/Codebase/Infrastructure/Dependency/Parser/CodebaseToParserInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\Dependency\Parser;
 

--- a/src/Codebase/Infrastructure/Exception/ParserIsNotDefinedException.php
+++ b/src/Codebase/Infrastructure/Exception/ParserIsNotDefinedException.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\Exception;
 
 use Exception;

--- a/src/Codebase/Infrastructure/Exception/ParserIsNotDefinedException.php
+++ b/src/Codebase/Infrastructure/Exception/ParserIsNotDefinedException.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\Exception;
 

--- a/src/Codebase/Infrastructure/Exception/ParserIsNotDefinedException.php
+++ b/src/Codebase/Infrastructure/Exception/ParserIsNotDefinedException.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\Exception;
 

--- a/src/Codebase/Infrastructure/Exception/ProjectConfigurationFileInvalidSyntaxException.php
+++ b/src/Codebase/Infrastructure/Exception/ProjectConfigurationFileInvalidSyntaxException.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\Exception;
 
 use Exception;

--- a/src/Codebase/Infrastructure/Exception/ProjectConfigurationFileInvalidSyntaxException.php
+++ b/src/Codebase/Infrastructure/Exception/ProjectConfigurationFileInvalidSyntaxException.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\Exception;
 

--- a/src/Codebase/Infrastructure/Exception/ProjectConfigurationFileInvalidSyntaxException.php
+++ b/src/Codebase/Infrastructure/Exception/ProjectConfigurationFileInvalidSyntaxException.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\Exception;
 

--- a/src/Codebase/Infrastructure/Service/CodebaseService.php
+++ b/src/Codebase/Infrastructure/Service/CodebaseService.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\Service;
 
 use Codebase\Application\Dto\CodeBaseRequestDto;

--- a/src/Codebase/Infrastructure/Service/CodebaseService.php
+++ b/src/Codebase/Infrastructure/Service/CodebaseService.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\Service;
 

--- a/src/Codebase/Infrastructure/Service/CodebaseService.php
+++ b/src/Codebase/Infrastructure/Service/CodebaseService.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\Service;
 

--- a/src/Codebase/Infrastructure/SourceFinder/ClassNodeFinder.php
+++ b/src/Codebase/Infrastructure/SourceFinder/ClassNodeFinder.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\SourceFinder;
 
 use PhpParser\Node;

--- a/src/Codebase/Infrastructure/SourceFinder/ClassNodeFinder.php
+++ b/src/Codebase/Infrastructure/SourceFinder/ClassNodeFinder.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\SourceFinder;
 

--- a/src/Codebase/Infrastructure/SourceFinder/ClassNodeFinder.php
+++ b/src/Codebase/Infrastructure/SourceFinder/ClassNodeFinder.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\SourceFinder;
 

--- a/src/Codebase/Infrastructure/SourceFinder/SourceFinder.php
+++ b/src/Codebase/Infrastructure/SourceFinder/SourceFinder.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\SourceFinder;
 
 use Codebase\Infrastructure\Dependency\Finder\CodebaseToFinderInterface;

--- a/src/Codebase/Infrastructure/SourceFinder/SourceFinder.php
+++ b/src/Codebase/Infrastructure/SourceFinder/SourceFinder.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\SourceFinder;
 

--- a/src/Codebase/Infrastructure/SourceFinder/SourceFinder.php
+++ b/src/Codebase/Infrastructure/SourceFinder/SourceFinder.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\SourceFinder;
 

--- a/src/Codebase/Infrastructure/SourceParser/Parser/DatabaseSchemaParser.php
+++ b/src/Codebase/Infrastructure/SourceParser/Parser/DatabaseSchemaParser.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\SourceParser\Parser;
 

--- a/src/Codebase/Infrastructure/SourceParser/Parser/DatabaseSchemaParser.php
+++ b/src/Codebase/Infrastructure/SourceParser/Parser/DatabaseSchemaParser.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\SourceParser\Parser;
 

--- a/src/Codebase/Infrastructure/SourceParser/Parser/DatabaseSchemaParser.php
+++ b/src/Codebase/Infrastructure/SourceParser/Parser/DatabaseSchemaParser.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\SourceParser\Parser;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/src/Codebase/Infrastructure/SourceParser/Parser/ParserInterface.php
+++ b/src/Codebase/Infrastructure/SourceParser/Parser/ParserInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\SourceParser\Parser;
 

--- a/src/Codebase/Infrastructure/SourceParser/Parser/ParserInterface.php
+++ b/src/Codebase/Infrastructure/SourceParser/Parser/ParserInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\SourceParser\Parser;
 

--- a/src/Codebase/Infrastructure/SourceParser/Parser/ParserInterface.php
+++ b/src/Codebase/Infrastructure/SourceParser/Parser/ParserInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\SourceParser\Parser;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/src/Codebase/Infrastructure/SourceParser/Parser/PhpParser.php
+++ b/src/Codebase/Infrastructure/SourceParser/Parser/PhpParser.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\SourceParser\Parser;
 
 use Codebase\Application\Dto\ClassCodebaseDto;

--- a/src/Codebase/Infrastructure/SourceParser/Parser/PhpParser.php
+++ b/src/Codebase/Infrastructure/SourceParser/Parser/PhpParser.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\SourceParser\Parser;
 

--- a/src/Codebase/Infrastructure/SourceParser/Parser/PhpParser.php
+++ b/src/Codebase/Infrastructure/SourceParser/Parser/PhpParser.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\SourceParser\Parser;
 

--- a/src/Codebase/Infrastructure/SourceParser/Parser/PhpParserInterface.php
+++ b/src/Codebase/Infrastructure/SourceParser/Parser/PhpParserInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\SourceParser\Parser;
 
 use Codebase\Application\Dto\ClassCodebaseDto;

--- a/src/Codebase/Infrastructure/SourceParser/Parser/PhpParserInterface.php
+++ b/src/Codebase/Infrastructure/SourceParser/Parser/PhpParserInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\SourceParser\Parser;
 

--- a/src/Codebase/Infrastructure/SourceParser/Parser/PhpParserInterface.php
+++ b/src/Codebase/Infrastructure/SourceParser/Parser/PhpParserInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\SourceParser\Parser;
 

--- a/src/Codebase/Infrastructure/SourceParser/Parser/TransferSchemaParser.php
+++ b/src/Codebase/Infrastructure/SourceParser/Parser/TransferSchemaParser.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\SourceParser\Parser;
 

--- a/src/Codebase/Infrastructure/SourceParser/Parser/TransferSchemaParser.php
+++ b/src/Codebase/Infrastructure/SourceParser/Parser/TransferSchemaParser.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\SourceParser\Parser;
 

--- a/src/Codebase/Infrastructure/SourceParser/Parser/TransferSchemaParser.php
+++ b/src/Codebase/Infrastructure/SourceParser/Parser/TransferSchemaParser.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\SourceParser\Parser;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/src/Codebase/Infrastructure/SourceParser/Parser/XmlParser.php
+++ b/src/Codebase/Infrastructure/SourceParser/Parser/XmlParser.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\SourceParser\Parser;
 
 use Codebase\Application\Dto\XmlDto;

--- a/src/Codebase/Infrastructure/SourceParser/Parser/XmlParser.php
+++ b/src/Codebase/Infrastructure/SourceParser/Parser/XmlParser.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\SourceParser\Parser;
 

--- a/src/Codebase/Infrastructure/SourceParser/Parser/XmlParser.php
+++ b/src/Codebase/Infrastructure/SourceParser/Parser/XmlParser.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\SourceParser\Parser;
 

--- a/src/Codebase/Infrastructure/SourceParser/SourceParser.php
+++ b/src/Codebase/Infrastructure/SourceParser/SourceParser.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\SourceParser;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/src/Codebase/Infrastructure/SourceParser/SourceParser.php
+++ b/src/Codebase/Infrastructure/SourceParser/SourceParser.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\SourceParser;
 

--- a/src/Codebase/Infrastructure/SourceParser/SourceParser.php
+++ b/src/Codebase/Infrastructure/SourceParser/SourceParser.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\SourceParser;
 

--- a/src/Codebase/Infrastructure/SourceParser/SourceParserInterface.php
+++ b/src/Codebase/Infrastructure/SourceParser/SourceParserInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\SourceParser;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/src/Codebase/Infrastructure/SourceParser/SourceParserInterface.php
+++ b/src/Codebase/Infrastructure/SourceParser/SourceParserInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\SourceParser;
 

--- a/src/Codebase/Infrastructure/SourceParser/SourceParserInterface.php
+++ b/src/Codebase/Infrastructure/SourceParser/SourceParserInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\SourceParser;
 

--- a/src/Codebase/Infrastructure/ToolingConfigurationReader/ToolingConfigurationReader.php
+++ b/src/Codebase/Infrastructure/ToolingConfigurationReader/ToolingConfigurationReader.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\ToolingConfigurationReader;
 

--- a/src/Codebase/Infrastructure/ToolingConfigurationReader/ToolingConfigurationReader.php
+++ b/src/Codebase/Infrastructure/ToolingConfigurationReader/ToolingConfigurationReader.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\ToolingConfigurationReader;
 
 use Codebase\Application\Dto\ConfigurationResponseDto;

--- a/src/Codebase/Infrastructure/ToolingConfigurationReader/ToolingConfigurationReader.php
+++ b/src/Codebase/Infrastructure/ToolingConfigurationReader/ToolingConfigurationReader.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\ToolingConfigurationReader;
 

--- a/src/Codebase/Infrastructure/ToolingConfigurationReader/ToolingConfigurationReaderInterface.php
+++ b/src/Codebase/Infrastructure/ToolingConfigurationReader/ToolingConfigurationReaderInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\ToolingConfigurationReader;
 

--- a/src/Codebase/Infrastructure/ToolingConfigurationReader/ToolingConfigurationReaderInterface.php
+++ b/src/Codebase/Infrastructure/ToolingConfigurationReader/ToolingConfigurationReaderInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\ToolingConfigurationReader;
 
 use Codebase\Application\Dto\ConfigurationResponseDto;

--- a/src/Codebase/Infrastructure/ToolingConfigurationReader/ToolingConfigurationReaderInterface.php
+++ b/src/Codebase/Infrastructure/ToolingConfigurationReader/ToolingConfigurationReaderInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\ToolingConfigurationReader;
 

--- a/src/Codebase/Infrastructure/ToolingConfigurationReader/Validator/ProjectPrefixesValidator.php
+++ b/src/Codebase/Infrastructure/ToolingConfigurationReader/Validator/ProjectPrefixesValidator.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\ToolingConfigurationReader\Validator;
 

--- a/src/Codebase/Infrastructure/ToolingConfigurationReader/Validator/ProjectPrefixesValidator.php
+++ b/src/Codebase/Infrastructure/ToolingConfigurationReader/Validator/ProjectPrefixesValidator.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\ToolingConfigurationReader\Validator;
 

--- a/src/Codebase/Infrastructure/ToolingConfigurationReader/Validator/ProjectPrefixesValidator.php
+++ b/src/Codebase/Infrastructure/ToolingConfigurationReader/Validator/ProjectPrefixesValidator.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\ToolingConfigurationReader\Validator;
 
 use Codebase\Application\Dto\ConfigurationResponseDto;

--- a/src/Codebase/Infrastructure/ToolingConfigurationReader/Validator/ToolingConfigurationValidatorInterface.php
+++ b/src/Codebase/Infrastructure/ToolingConfigurationReader/Validator/ToolingConfigurationValidatorInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Codebase\Infrastructure\ToolingConfigurationReader\Validator;
 
 interface ToolingConfigurationValidatorInterface

--- a/src/Codebase/Infrastructure/ToolingConfigurationReader/Validator/ToolingConfigurationValidatorInterface.php
+++ b/src/Codebase/Infrastructure/ToolingConfigurationReader/Validator/ToolingConfigurationValidatorInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Codebase\Infrastructure\ToolingConfigurationReader\Validator;
 

--- a/src/Codebase/Infrastructure/ToolingConfigurationReader/Validator/ToolingConfigurationValidatorInterface.php
+++ b/src/Codebase/Infrastructure/ToolingConfigurationReader/Validator/ToolingConfigurationValidatorInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Codebase\Infrastructure\ToolingConfigurationReader\Validator;
 

--- a/src/Core/Domain/ValueObject/Id.php
+++ b/src/Core/Domain/ValueObject/Id.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Core\Domain\ValueObject;
 

--- a/src/Core/Domain/ValueObject/Id.php
+++ b/src/Core/Domain/ValueObject/Id.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Core\Domain\ValueObject;
 
 class Id

--- a/src/Core/Domain/ValueObject/Id.php
+++ b/src/Core/Domain/ValueObject/Id.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Core\Domain\ValueObject;
 

--- a/src/Core/Infrastructure/Service/ProcessRunnerService.php
+++ b/src/Core/Infrastructure/Service/ProcessRunnerService.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Core\Infrastructure\Service;
 
 use Symfony\Component\Process\Process;

--- a/src/Core/Infrastructure/Service/ProcessRunnerService.php
+++ b/src/Core/Infrastructure/Service/ProcessRunnerService.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Core\Infrastructure\Service;
 

--- a/src/Core/Infrastructure/Service/ProcessRunnerService.php
+++ b/src/Core/Infrastructure/Service/ProcessRunnerService.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Core\Infrastructure\Service;
 

--- a/src/Core/Infrastructure/Service/ProcessRunnerServiceInterface.php
+++ b/src/Core/Infrastructure/Service/ProcessRunnerServiceInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Core\Infrastructure\Service;
 
 use Symfony\Component\Process\Process;

--- a/src/Core/Infrastructure/Service/ProcessRunnerServiceInterface.php
+++ b/src/Core/Infrastructure/Service/ProcessRunnerServiceInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Core\Infrastructure\Service;
 

--- a/src/Core/Infrastructure/Service/ProcessRunnerServiceInterface.php
+++ b/src/Core/Infrastructure/Service/ProcessRunnerServiceInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Core\Infrastructure\Service;
 

--- a/src/ReleaseApp/Application/Configuration/ConfigurationProviderInterface.php
+++ b/src/ReleaseApp/Application/Configuration/ConfigurationProviderInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Application\Configuration;
 
 interface ConfigurationProviderInterface

--- a/src/ReleaseApp/Application/Configuration/ConfigurationProviderInterface.php
+++ b/src/ReleaseApp/Application/Configuration/ConfigurationProviderInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Application\Configuration;
 

--- a/src/ReleaseApp/Application/Configuration/ConfigurationProviderInterface.php
+++ b/src/ReleaseApp/Application/Configuration/ConfigurationProviderInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Application\Configuration;
 

--- a/src/ReleaseApp/Application/Configuration/ReleaseAppConstant.php
+++ b/src/ReleaseApp/Application/Configuration/ReleaseAppConstant.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Application\Configuration;
 
 class ReleaseAppConstant

--- a/src/ReleaseApp/Application/Configuration/ReleaseAppConstant.php
+++ b/src/ReleaseApp/Application/Configuration/ReleaseAppConstant.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Application\Configuration;
 

--- a/src/ReleaseApp/Application/Configuration/ReleaseAppConstant.php
+++ b/src/ReleaseApp/Application/Configuration/ReleaseAppConstant.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Application\Configuration;
 

--- a/src/ReleaseApp/Application/Service/ReleaseAppService.php
+++ b/src/ReleaseApp/Application/Service/ReleaseAppService.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Application\Service;
 

--- a/src/ReleaseApp/Application/Service/ReleaseAppService.php
+++ b/src/ReleaseApp/Application/Service/ReleaseAppService.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Application\Service;
 
 use ReleaseApp\Application\Configuration\ConfigurationProviderInterface;

--- a/src/ReleaseApp/Application/Service/ReleaseAppService.php
+++ b/src/ReleaseApp/Application/Service/ReleaseAppService.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Application\Service;
 

--- a/src/ReleaseApp/Application/Service/ReleaseAppServiceInterface.php
+++ b/src/ReleaseApp/Application/Service/ReleaseAppServiceInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Application\Service;
 

--- a/src/ReleaseApp/Application/Service/ReleaseAppServiceInterface.php
+++ b/src/ReleaseApp/Application/Service/ReleaseAppServiceInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Application\Service;
 

--- a/src/ReleaseApp/Application/Service/ReleaseAppServiceInterface.php
+++ b/src/ReleaseApp/Application/Service/ReleaseAppServiceInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Application\Service;
 
 use ReleaseApp\Domain\Client\Request\UpgradeAnalysisRequest;

--- a/src/ReleaseApp/Domain/Client/ReleaseAppClientInterface.php
+++ b/src/ReleaseApp/Domain/Client/ReleaseAppClientInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Client;
 

--- a/src/ReleaseApp/Domain/Client/ReleaseAppClientInterface.php
+++ b/src/ReleaseApp/Domain/Client/ReleaseAppClientInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Client;
 

--- a/src/ReleaseApp/Domain/Client/ReleaseAppClientInterface.php
+++ b/src/ReleaseApp/Domain/Client/ReleaseAppClientInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Domain\Client;
 
 use ReleaseApp\Domain\Client\Request\UpgradeAnalysisRequest;

--- a/src/ReleaseApp/Domain/Client/Request/RequestInterface.php
+++ b/src/ReleaseApp/Domain/Client/Request/RequestInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Client\Request;
 

--- a/src/ReleaseApp/Domain/Client/Request/RequestInterface.php
+++ b/src/ReleaseApp/Domain/Client/Request/RequestInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Domain\Client\Request;
 
 interface RequestInterface

--- a/src/ReleaseApp/Domain/Client/Request/RequestInterface.php
+++ b/src/ReleaseApp/Domain/Client/Request/RequestInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Client\Request;
 

--- a/src/ReleaseApp/Domain/Client/Request/UpgradeAnalysisRequest.php
+++ b/src/ReleaseApp/Domain/Client/Request/UpgradeAnalysisRequest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Client\Request;
 

--- a/src/ReleaseApp/Domain/Client/Request/UpgradeAnalysisRequest.php
+++ b/src/ReleaseApp/Domain/Client/Request/UpgradeAnalysisRequest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Domain\Client\Request;
 
 use ReleaseApp\Domain\Entities\UpgradeAnalysis;

--- a/src/ReleaseApp/Domain/Client/Request/UpgradeAnalysisRequest.php
+++ b/src/ReleaseApp/Domain/Client/Request/UpgradeAnalysisRequest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Client\Request;
 

--- a/src/ReleaseApp/Domain/Client/Request/UpgradeInstructionsRequest.php
+++ b/src/ReleaseApp/Domain/Client/Request/UpgradeInstructionsRequest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Client\Request;
 

--- a/src/ReleaseApp/Domain/Client/Request/UpgradeInstructionsRequest.php
+++ b/src/ReleaseApp/Domain/Client/Request/UpgradeInstructionsRequest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Domain\Client\Request;
 
 use ReleaseApp\Domain\Entities\UpgradeInstructions;

--- a/src/ReleaseApp/Domain/Client/Request/UpgradeInstructionsRequest.php
+++ b/src/ReleaseApp/Domain/Client/Request/UpgradeInstructionsRequest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Client\Request;
 

--- a/src/ReleaseApp/Domain/Client/Response/Response.php
+++ b/src/ReleaseApp/Domain/Client/Response/Response.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Client\Response;
 

--- a/src/ReleaseApp/Domain/Client/Response/Response.php
+++ b/src/ReleaseApp/Domain/Client/Response/Response.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Domain\Client\Response;
 
 class Response implements ResponseInterface

--- a/src/ReleaseApp/Domain/Client/Response/Response.php
+++ b/src/ReleaseApp/Domain/Client/Response/Response.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Client\Response;
 

--- a/src/ReleaseApp/Domain/Client/Response/ResponseInterface.php
+++ b/src/ReleaseApp/Domain/Client/Response/ResponseInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Client\Response;
 

--- a/src/ReleaseApp/Domain/Client/Response/ResponseInterface.php
+++ b/src/ReleaseApp/Domain/Client/Response/ResponseInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Client\Response;
 

--- a/src/ReleaseApp/Domain/Client/Response/ResponseInterface.php
+++ b/src/ReleaseApp/Domain/Client/Response/ResponseInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Domain\Client\Response;
 
 interface ResponseInterface

--- a/src/ReleaseApp/Domain/Entities/Collection/UpgradeAnalysisModuleCollection.php
+++ b/src/ReleaseApp/Domain/Entities/Collection/UpgradeAnalysisModuleCollection.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Domain\Entities\Collection;
 
 use ReleaseApp\Domain\Entities\UpgradeAnalysisModule;

--- a/src/ReleaseApp/Domain/Entities/Collection/UpgradeAnalysisModuleCollection.php
+++ b/src/ReleaseApp/Domain/Entities/Collection/UpgradeAnalysisModuleCollection.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Entities\Collection;
 

--- a/src/ReleaseApp/Domain/Entities/Collection/UpgradeAnalysisModuleCollection.php
+++ b/src/ReleaseApp/Domain/Entities/Collection/UpgradeAnalysisModuleCollection.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Entities\Collection;
 

--- a/src/ReleaseApp/Domain/Entities/Collection/UpgradeAnalysisModuleVersionCollection.php
+++ b/src/ReleaseApp/Domain/Entities/Collection/UpgradeAnalysisModuleVersionCollection.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Domain\Entities\Collection;
 
 use ReleaseApp\Domain\Entities\UpgradeAnalysisModuleVersion;

--- a/src/ReleaseApp/Domain/Entities/Collection/UpgradeAnalysisModuleVersionCollection.php
+++ b/src/ReleaseApp/Domain/Entities/Collection/UpgradeAnalysisModuleVersionCollection.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Entities\Collection;
 

--- a/src/ReleaseApp/Domain/Entities/Collection/UpgradeAnalysisModuleVersionCollection.php
+++ b/src/ReleaseApp/Domain/Entities/Collection/UpgradeAnalysisModuleVersionCollection.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Entities\Collection;
 

--- a/src/ReleaseApp/Domain/Entities/Collection/UpgradeInstructionModuleCollection.php
+++ b/src/ReleaseApp/Domain/Entities/Collection/UpgradeInstructionModuleCollection.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Entities\Collection;
 

--- a/src/ReleaseApp/Domain/Entities/Collection/UpgradeInstructionModuleCollection.php
+++ b/src/ReleaseApp/Domain/Entities/Collection/UpgradeInstructionModuleCollection.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Entities\Collection;
 

--- a/src/ReleaseApp/Domain/Entities/Collection/UpgradeInstructionModuleCollection.php
+++ b/src/ReleaseApp/Domain/Entities/Collection/UpgradeInstructionModuleCollection.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Domain\Entities\Collection;
 
 use ReleaseApp\Domain\Entities\UpgradeInstructionModule;

--- a/src/ReleaseApp/Domain/Entities/Collection/UpgradeInstructionsReleaseGroupCollection.php
+++ b/src/ReleaseApp/Domain/Entities/Collection/UpgradeInstructionsReleaseGroupCollection.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Entities\Collection;
 

--- a/src/ReleaseApp/Domain/Entities/Collection/UpgradeInstructionsReleaseGroupCollection.php
+++ b/src/ReleaseApp/Domain/Entities/Collection/UpgradeInstructionsReleaseGroupCollection.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Entities\Collection;
 

--- a/src/ReleaseApp/Domain/Entities/Collection/UpgradeInstructionsReleaseGroupCollection.php
+++ b/src/ReleaseApp/Domain/Entities/Collection/UpgradeInstructionsReleaseGroupCollection.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Domain\Entities\Collection;
 
 use ReleaseApp\Domain\Entities\UpgradeInstructionsReleaseGroup;

--- a/src/ReleaseApp/Domain/Entities/UpgradeAnalysis.php
+++ b/src/ReleaseApp/Domain/Entities/UpgradeAnalysis.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Entities;
 

--- a/src/ReleaseApp/Domain/Entities/UpgradeAnalysis.php
+++ b/src/ReleaseApp/Domain/Entities/UpgradeAnalysis.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Entities;
 

--- a/src/ReleaseApp/Domain/Entities/UpgradeAnalysis.php
+++ b/src/ReleaseApp/Domain/Entities/UpgradeAnalysis.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Domain\Entities;
 
 use ReleaseApp\Domain\Client\Response\Response;

--- a/src/ReleaseApp/Domain/Entities/UpgradeAnalysisModule.php
+++ b/src/ReleaseApp/Domain/Entities/UpgradeAnalysisModule.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Entities;
 

--- a/src/ReleaseApp/Domain/Entities/UpgradeAnalysisModule.php
+++ b/src/ReleaseApp/Domain/Entities/UpgradeAnalysisModule.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Entities;
 

--- a/src/ReleaseApp/Domain/Entities/UpgradeAnalysisModule.php
+++ b/src/ReleaseApp/Domain/Entities/UpgradeAnalysisModule.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Domain\Entities;
 
 use ReleaseApp\Domain\Entities\Collection\UpgradeAnalysisModuleVersionCollection;

--- a/src/ReleaseApp/Domain/Entities/UpgradeAnalysisModuleVersion.php
+++ b/src/ReleaseApp/Domain/Entities/UpgradeAnalysisModuleVersion.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Entities;
 

--- a/src/ReleaseApp/Domain/Entities/UpgradeAnalysisModuleVersion.php
+++ b/src/ReleaseApp/Domain/Entities/UpgradeAnalysisModuleVersion.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Domain\Entities;
 
 use DateTime;

--- a/src/ReleaseApp/Domain/Entities/UpgradeAnalysisModuleVersion.php
+++ b/src/ReleaseApp/Domain/Entities/UpgradeAnalysisModuleVersion.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Entities;
 

--- a/src/ReleaseApp/Domain/Entities/UpgradeInstructionModule.php
+++ b/src/ReleaseApp/Domain/Entities/UpgradeInstructionModule.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Entities;
 

--- a/src/ReleaseApp/Domain/Entities/UpgradeInstructionModule.php
+++ b/src/ReleaseApp/Domain/Entities/UpgradeInstructionModule.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Domain\Entities;
 
 use Upgrade\Application\Exception\UpgraderException;

--- a/src/ReleaseApp/Domain/Entities/UpgradeInstructionModule.php
+++ b/src/ReleaseApp/Domain/Entities/UpgradeInstructionModule.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Entities;
 

--- a/src/ReleaseApp/Domain/Entities/UpgradeInstructions.php
+++ b/src/ReleaseApp/Domain/Entities/UpgradeInstructions.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Entities;
 

--- a/src/ReleaseApp/Domain/Entities/UpgradeInstructions.php
+++ b/src/ReleaseApp/Domain/Entities/UpgradeInstructions.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Entities;
 

--- a/src/ReleaseApp/Domain/Entities/UpgradeInstructions.php
+++ b/src/ReleaseApp/Domain/Entities/UpgradeInstructions.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Domain\Entities;
 
 use ReleaseApp\Domain\Client\Response\Response;

--- a/src/ReleaseApp/Domain/Entities/UpgradeInstructionsReleaseGroup.php
+++ b/src/ReleaseApp/Domain/Entities/UpgradeInstructionsReleaseGroup.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Entities;
 

--- a/src/ReleaseApp/Domain/Entities/UpgradeInstructionsReleaseGroup.php
+++ b/src/ReleaseApp/Domain/Entities/UpgradeInstructionsReleaseGroup.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Domain\Entities;
 
 use DateTime;

--- a/src/ReleaseApp/Domain/Entities/UpgradeInstructionsReleaseGroup.php
+++ b/src/ReleaseApp/Domain/Entities/UpgradeInstructionsReleaseGroup.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Domain\Entities;
 

--- a/src/ReleaseApp/Infrastructure/Client/Builder/HttpRequestBuilder.php
+++ b/src/ReleaseApp/Infrastructure/Client/Builder/HttpRequestBuilder.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Client\Builder;
 

--- a/src/ReleaseApp/Infrastructure/Client/Builder/HttpRequestBuilder.php
+++ b/src/ReleaseApp/Infrastructure/Client/Builder/HttpRequestBuilder.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Client\Builder;
 

--- a/src/ReleaseApp/Infrastructure/Client/Builder/HttpRequestBuilder.php
+++ b/src/ReleaseApp/Infrastructure/Client/Builder/HttpRequestBuilder.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Infrastructure\Client\Builder;
 
 use GuzzleHttp\Psr7\Request;

--- a/src/ReleaseApp/Infrastructure/Client/Builder/HttpRequestBuilderInterface.php
+++ b/src/ReleaseApp/Infrastructure/Client/Builder/HttpRequestBuilderInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Client\Builder;
 

--- a/src/ReleaseApp/Infrastructure/Client/Builder/HttpRequestBuilderInterface.php
+++ b/src/ReleaseApp/Infrastructure/Client/Builder/HttpRequestBuilderInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Client\Builder;
 

--- a/src/ReleaseApp/Infrastructure/Client/Builder/HttpRequestBuilderInterface.php
+++ b/src/ReleaseApp/Infrastructure/Client/Builder/HttpRequestBuilderInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Infrastructure\Client\Builder;
 
 use GuzzleHttp\Psr7\Request;

--- a/src/ReleaseApp/Infrastructure/Client/Builder/HttpResponseBuilder.php
+++ b/src/ReleaseApp/Infrastructure/Client/Builder/HttpResponseBuilder.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Client\Builder;
 

--- a/src/ReleaseApp/Infrastructure/Client/Builder/HttpResponseBuilder.php
+++ b/src/ReleaseApp/Infrastructure/Client/Builder/HttpResponseBuilder.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Client\Builder;
 

--- a/src/ReleaseApp/Infrastructure/Client/Builder/HttpResponseBuilder.php
+++ b/src/ReleaseApp/Infrastructure/Client/Builder/HttpResponseBuilder.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Infrastructure\Client\Builder;
 
 use Psr\Http\Message\ResponseInterface;

--- a/src/ReleaseApp/Infrastructure/Client/Builder/HttpResponseBuilderInterface.php
+++ b/src/ReleaseApp/Infrastructure/Client/Builder/HttpResponseBuilderInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Client\Builder;
 

--- a/src/ReleaseApp/Infrastructure/Client/Builder/HttpResponseBuilderInterface.php
+++ b/src/ReleaseApp/Infrastructure/Client/Builder/HttpResponseBuilderInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Client\Builder;
 

--- a/src/ReleaseApp/Infrastructure/Client/Builder/HttpResponseBuilderInterface.php
+++ b/src/ReleaseApp/Infrastructure/Client/Builder/HttpResponseBuilderInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Infrastructure\Client\Builder;
 
 use Psr\Http\Message\ResponseInterface;

--- a/src/ReleaseApp/Infrastructure/Client/HttpReleaseAppClient.php
+++ b/src/ReleaseApp/Infrastructure/Client/HttpReleaseAppClient.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Client;
 

--- a/src/ReleaseApp/Infrastructure/Client/HttpReleaseAppClient.php
+++ b/src/ReleaseApp/Infrastructure/Client/HttpReleaseAppClient.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Infrastructure\Client;
 
 use ReleaseApp\Domain\Client\ReleaseAppClientInterface;

--- a/src/ReleaseApp/Infrastructure/Client/HttpReleaseAppClient.php
+++ b/src/ReleaseApp/Infrastructure/Client/HttpReleaseAppClient.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Client;
 

--- a/src/ReleaseApp/Infrastructure/Client/HttpRequestExecutor.php
+++ b/src/ReleaseApp/Infrastructure/Client/HttpRequestExecutor.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Client;
 

--- a/src/ReleaseApp/Infrastructure/Client/HttpRequestExecutor.php
+++ b/src/ReleaseApp/Infrastructure/Client/HttpRequestExecutor.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Infrastructure\Client;
 
 use GuzzleHttp\Client;

--- a/src/ReleaseApp/Infrastructure/Client/HttpRequestExecutor.php
+++ b/src/ReleaseApp/Infrastructure/Client/HttpRequestExecutor.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Client;
 

--- a/src/ReleaseApp/Infrastructure/Client/HttpRequestExecutorInterface.php
+++ b/src/ReleaseApp/Infrastructure/Client/HttpRequestExecutorInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Infrastructure\Client;
 
 use Psr\Http\Message\RequestInterface;

--- a/src/ReleaseApp/Infrastructure/Client/HttpRequestExecutorInterface.php
+++ b/src/ReleaseApp/Infrastructure/Client/HttpRequestExecutorInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Client;
 

--- a/src/ReleaseApp/Infrastructure/Client/HttpRequestExecutorInterface.php
+++ b/src/ReleaseApp/Infrastructure/Client/HttpRequestExecutorInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Client;
 

--- a/src/ReleaseApp/Infrastructure/Client/Request/HttpRequestInterface.php
+++ b/src/ReleaseApp/Infrastructure/Client/Request/HttpRequestInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Client\Request;
 

--- a/src/ReleaseApp/Infrastructure/Client/Request/HttpRequestInterface.php
+++ b/src/ReleaseApp/Infrastructure/Client/Request/HttpRequestInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Client\Request;
 

--- a/src/ReleaseApp/Infrastructure/Client/Request/HttpRequestInterface.php
+++ b/src/ReleaseApp/Infrastructure/Client/Request/HttpRequestInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Infrastructure\Client\Request;
 
 use ReleaseApp\Domain\Client\Request\RequestInterface;

--- a/src/ReleaseApp/Infrastructure/Client/Request/HttpUpgradeAnalysisHttpRequest.php
+++ b/src/ReleaseApp/Infrastructure/Client/Request/HttpUpgradeAnalysisHttpRequest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Client\Request;
 

--- a/src/ReleaseApp/Infrastructure/Client/Request/HttpUpgradeAnalysisHttpRequest.php
+++ b/src/ReleaseApp/Infrastructure/Client/Request/HttpUpgradeAnalysisHttpRequest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Client\Request;
 

--- a/src/ReleaseApp/Infrastructure/Client/Request/HttpUpgradeAnalysisHttpRequest.php
+++ b/src/ReleaseApp/Infrastructure/Client/Request/HttpUpgradeAnalysisHttpRequest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Infrastructure\Client\Request;
 
 use ReleaseApp\Domain\Client\Request\RequestInterface;

--- a/src/ReleaseApp/Infrastructure/Client/Request/HttpUpgradeInstructionsRequest.php
+++ b/src/ReleaseApp/Infrastructure/Client/Request/HttpUpgradeInstructionsRequest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Client\Request;
 

--- a/src/ReleaseApp/Infrastructure/Client/Request/HttpUpgradeInstructionsRequest.php
+++ b/src/ReleaseApp/Infrastructure/Client/Request/HttpUpgradeInstructionsRequest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Client\Request;
 

--- a/src/ReleaseApp/Infrastructure/Client/Request/HttpUpgradeInstructionsRequest.php
+++ b/src/ReleaseApp/Infrastructure/Client/Request/HttpUpgradeInstructionsRequest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Infrastructure\Client\Request;
 
 use ReleaseApp\Domain\Client\Request\RequestInterface;

--- a/src/ReleaseApp/Infrastructure/Configuration/ConfigurationProvider.php
+++ b/src/ReleaseApp/Infrastructure/Configuration/ConfigurationProvider.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Infrastructure\Configuration;
 
 use ReleaseApp\Application\Configuration\ConfigurationProviderInterface;

--- a/src/ReleaseApp/Infrastructure/Configuration/ConfigurationProvider.php
+++ b/src/ReleaseApp/Infrastructure/Configuration/ConfigurationProvider.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Configuration;
 

--- a/src/ReleaseApp/Infrastructure/Configuration/ConfigurationProvider.php
+++ b/src/ReleaseApp/Infrastructure/Configuration/ConfigurationProvider.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Configuration;
 

--- a/src/ReleaseApp/Infrastructure/Service/ReleaseAppService.php
+++ b/src/ReleaseApp/Infrastructure/Service/ReleaseAppService.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Service;
 

--- a/src/ReleaseApp/Infrastructure/Service/ReleaseAppService.php
+++ b/src/ReleaseApp/Infrastructure/Service/ReleaseAppService.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Infrastructure\Service;
 
 use ReleaseApp\Application\Service\ReleaseAppService as ApplicationReleaseAppService;

--- a/src/ReleaseApp/Infrastructure/Service/ReleaseAppService.php
+++ b/src/ReleaseApp/Infrastructure/Service/ReleaseAppService.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Service;
 

--- a/src/ReleaseApp/Infrastructure/Service/ReleaseAppServiceInterface.php
+++ b/src/ReleaseApp/Infrastructure/Service/ReleaseAppServiceInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Service;
 

--- a/src/ReleaseApp/Infrastructure/Service/ReleaseAppServiceInterface.php
+++ b/src/ReleaseApp/Infrastructure/Service/ReleaseAppServiceInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Infrastructure\Service;
 
 use ReleaseApp\Domain\Client\Request\UpgradeAnalysisRequest;

--- a/src/ReleaseApp/Infrastructure/Service/ReleaseAppServiceInterface.php
+++ b/src/ReleaseApp/Infrastructure/Service/ReleaseAppServiceInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Service;
 

--- a/src/ReleaseApp/Infrastructure/Shared/Dto/Collection/ModuleDtoCollection.php
+++ b/src/ReleaseApp/Infrastructure/Shared/Dto/Collection/ModuleDtoCollection.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Shared\Dto\Collection;
 

--- a/src/ReleaseApp/Infrastructure/Shared/Dto/Collection/ModuleDtoCollection.php
+++ b/src/ReleaseApp/Infrastructure/Shared/Dto/Collection/ModuleDtoCollection.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Infrastructure\Shared\Dto\Collection;
 
 use ReleaseApp\Application\Configuration\ReleaseAppConstant;

--- a/src/ReleaseApp/Infrastructure/Shared/Dto/Collection/ModuleDtoCollection.php
+++ b/src/ReleaseApp/Infrastructure/Shared/Dto/Collection/ModuleDtoCollection.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Shared\Dto\Collection;
 

--- a/src/ReleaseApp/Infrastructure/Shared/Dto/Collection/ReleaseGroupDtoCollection.php
+++ b/src/ReleaseApp/Infrastructure/Shared/Dto/Collection/ReleaseGroupDtoCollection.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Shared\Dto\Collection;
 

--- a/src/ReleaseApp/Infrastructure/Shared/Dto/Collection/ReleaseGroupDtoCollection.php
+++ b/src/ReleaseApp/Infrastructure/Shared/Dto/Collection/ReleaseGroupDtoCollection.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Infrastructure\Shared\Dto\Collection;
 
 use ReleaseApp\Infrastructure\Shared\Dto\ReleaseGroupDto;

--- a/src/ReleaseApp/Infrastructure/Shared/Dto/Collection/ReleaseGroupDtoCollection.php
+++ b/src/ReleaseApp/Infrastructure/Shared/Dto/Collection/ReleaseGroupDtoCollection.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Shared\Dto\Collection;
 

--- a/src/ReleaseApp/Infrastructure/Shared/Dto/ModuleDto.php
+++ b/src/ReleaseApp/Infrastructure/Shared/Dto/ModuleDto.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Shared\Dto;
 

--- a/src/ReleaseApp/Infrastructure/Shared/Dto/ModuleDto.php
+++ b/src/ReleaseApp/Infrastructure/Shared/Dto/ModuleDto.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Shared\Dto;
 

--- a/src/ReleaseApp/Infrastructure/Shared/Dto/ModuleDto.php
+++ b/src/ReleaseApp/Infrastructure/Shared/Dto/ModuleDto.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Infrastructure\Shared\Dto;
 
 class ModuleDto

--- a/src/ReleaseApp/Infrastructure/Shared/Dto/ReleaseAppResponse.php
+++ b/src/ReleaseApp/Infrastructure/Shared/Dto/ReleaseAppResponse.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Shared\Dto;
 

--- a/src/ReleaseApp/Infrastructure/Shared/Dto/ReleaseAppResponse.php
+++ b/src/ReleaseApp/Infrastructure/Shared/Dto/ReleaseAppResponse.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Infrastructure\Shared\Dto;
 
 use ReleaseApp\Infrastructure\Shared\Dto\Collection\ReleaseGroupDtoCollection;

--- a/src/ReleaseApp/Infrastructure/Shared/Dto/ReleaseAppResponse.php
+++ b/src/ReleaseApp/Infrastructure/Shared/Dto/ReleaseAppResponse.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Shared\Dto;
 

--- a/src/ReleaseApp/Infrastructure/Shared/Dto/ReleaseGroupDto.php
+++ b/src/ReleaseApp/Infrastructure/Shared/Dto/ReleaseGroupDto.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Shared\Dto;
 

--- a/src/ReleaseApp/Infrastructure/Shared/Dto/ReleaseGroupDto.php
+++ b/src/ReleaseApp/Infrastructure/Shared/Dto/ReleaseGroupDto.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Shared\Dto;
 

--- a/src/ReleaseApp/Infrastructure/Shared/Dto/ReleaseGroupDto.php
+++ b/src/ReleaseApp/Infrastructure/Shared/Dto/ReleaseGroupDto.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Infrastructure\Shared\Dto;
 
 use ReleaseApp\Infrastructure\Shared\Dto\Collection\ModuleDtoCollection;

--- a/src/ReleaseApp/Infrastructure/Shared/Mapper/ReleaseGroupDtoCollectionMapper.php
+++ b/src/ReleaseApp/Infrastructure/Shared/Mapper/ReleaseGroupDtoCollectionMapper.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Shared\Mapper;
 

--- a/src/ReleaseApp/Infrastructure/Shared/Mapper/ReleaseGroupDtoCollectionMapper.php
+++ b/src/ReleaseApp/Infrastructure/Shared/Mapper/ReleaseGroupDtoCollectionMapper.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace ReleaseApp\Infrastructure\Shared\Mapper;
 

--- a/src/ReleaseApp/Infrastructure/Shared/Mapper/ReleaseGroupDtoCollectionMapper.php
+++ b/src/ReleaseApp/Infrastructure/Shared/Mapper/ReleaseGroupDtoCollectionMapper.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace ReleaseApp\Infrastructure\Shared\Mapper;
 
 use ReleaseApp\Application\Configuration\ConfigurationProviderInterface;

--- a/src/Upgrade/Application/Adapter/IntegratorAdapterInterface.php
+++ b/src/Upgrade/Application/Adapter/IntegratorAdapterInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Adapter;
 

--- a/src/Upgrade/Application/Adapter/IntegratorAdapterInterface.php
+++ b/src/Upgrade/Application/Adapter/IntegratorAdapterInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Adapter;
 
 use Upgrade\Application\Dto\StepsResponseDto;

--- a/src/Upgrade/Application/Adapter/IntegratorAdapterInterface.php
+++ b/src/Upgrade/Application/Adapter/IntegratorAdapterInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Adapter;
 

--- a/src/Upgrade/Application/Adapter/PackageManagerAdapterInterface.php
+++ b/src/Upgrade/Application/Adapter/PackageManagerAdapterInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Adapter;
 

--- a/src/Upgrade/Application/Adapter/PackageManagerAdapterInterface.php
+++ b/src/Upgrade/Application/Adapter/PackageManagerAdapterInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Adapter;
 
 use Upgrade\Application\Dto\ComposerLockDiffDto;

--- a/src/Upgrade/Application/Adapter/PackageManagerAdapterInterface.php
+++ b/src/Upgrade/Application/Adapter/PackageManagerAdapterInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Adapter;
 

--- a/src/Upgrade/Application/Adapter/ReleaseAppClientAdapterInterface.php
+++ b/src/Upgrade/Application/Adapter/ReleaseAppClientAdapterInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Adapter;
 
 use ReleaseApp\Infrastructure\Shared\Dto\ReleaseAppResponse;

--- a/src/Upgrade/Application/Adapter/ReleaseAppClientAdapterInterface.php
+++ b/src/Upgrade/Application/Adapter/ReleaseAppClientAdapterInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Adapter;
 

--- a/src/Upgrade/Application/Adapter/ReleaseAppClientAdapterInterface.php
+++ b/src/Upgrade/Application/Adapter/ReleaseAppClientAdapterInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Adapter;
 

--- a/src/Upgrade/Application/Adapter/VersionControlSystemAdapterInterface.php
+++ b/src/Upgrade/Application/Adapter/VersionControlSystemAdapterInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Adapter;
 

--- a/src/Upgrade/Application/Adapter/VersionControlSystemAdapterInterface.php
+++ b/src/Upgrade/Application/Adapter/VersionControlSystemAdapterInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Adapter;
 
 use Upgrade\Application\Dto\StepsResponseDto;

--- a/src/Upgrade/Application/Adapter/VersionControlSystemAdapterInterface.php
+++ b/src/Upgrade/Application/Adapter/VersionControlSystemAdapterInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Adapter;
 

--- a/src/Upgrade/Application/Dto/ComposerLockDiffDto.php
+++ b/src/Upgrade/Application/Dto/ComposerLockDiffDto.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Dto;
 

--- a/src/Upgrade/Application/Dto/ComposerLockDiffDto.php
+++ b/src/Upgrade/Application/Dto/ComposerLockDiffDto.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Dto;
 

--- a/src/Upgrade/Application/Dto/ComposerLockDiffDto.php
+++ b/src/Upgrade/Application/Dto/ComposerLockDiffDto.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Dto;
 
 use Upgrade\Domain\Entity\Package;

--- a/src/Upgrade/Application/Dto/ResponseDto.php
+++ b/src/Upgrade/Application/Dto/ResponseDto.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Dto;
 
 class ResponseDto

--- a/src/Upgrade/Application/Dto/ResponseDto.php
+++ b/src/Upgrade/Application/Dto/ResponseDto.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Dto;
 

--- a/src/Upgrade/Application/Dto/ResponseDto.php
+++ b/src/Upgrade/Application/Dto/ResponseDto.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Dto;
 

--- a/src/Upgrade/Application/Dto/StepsResponseDto.php
+++ b/src/Upgrade/Application/Dto/StepsResponseDto.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Dto;
 

--- a/src/Upgrade/Application/Dto/StepsResponseDto.php
+++ b/src/Upgrade/Application/Dto/StepsResponseDto.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Dto;
 

--- a/src/Upgrade/Application/Dto/StepsResponseDto.php
+++ b/src/Upgrade/Application/Dto/StepsResponseDto.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Dto;
 
 class StepsResponseDto extends ResponseDto

--- a/src/Upgrade/Application/Exception/ReleaseGroupRequireProcessorIsNotDefinedException.php
+++ b/src/Upgrade/Application/Exception/ReleaseGroupRequireProcessorIsNotDefinedException.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Exception;
 
 use Exception;

--- a/src/Upgrade/Application/Exception/ReleaseGroupRequireProcessorIsNotDefinedException.php
+++ b/src/Upgrade/Application/Exception/ReleaseGroupRequireProcessorIsNotDefinedException.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Exception;
 

--- a/src/Upgrade/Application/Exception/ReleaseGroupRequireProcessorIsNotDefinedException.php
+++ b/src/Upgrade/Application/Exception/ReleaseGroupRequireProcessorIsNotDefinedException.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Exception;
 

--- a/src/Upgrade/Application/Exception/ReleaseGroupThresholdException.php
+++ b/src/Upgrade/Application/Exception/ReleaseGroupThresholdException.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Exception;
 
 class ReleaseGroupThresholdException extends UpgraderException

--- a/src/Upgrade/Application/Exception/ReleaseGroupThresholdException.php
+++ b/src/Upgrade/Application/Exception/ReleaseGroupThresholdException.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Exception;
 

--- a/src/Upgrade/Application/Exception/ReleaseGroupThresholdException.php
+++ b/src/Upgrade/Application/Exception/ReleaseGroupThresholdException.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Exception;
 

--- a/src/Upgrade/Application/Exception/ReleaseGroupValidatorException.php
+++ b/src/Upgrade/Application/Exception/ReleaseGroupValidatorException.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Exception;
 
 class ReleaseGroupValidatorException extends UpgraderException

--- a/src/Upgrade/Application/Exception/ReleaseGroupValidatorException.php
+++ b/src/Upgrade/Application/Exception/ReleaseGroupValidatorException.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Exception;
 

--- a/src/Upgrade/Application/Exception/ReleaseGroupValidatorException.php
+++ b/src/Upgrade/Application/Exception/ReleaseGroupValidatorException.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Exception;
 

--- a/src/Upgrade/Application/Exception/UpgradeStrategyIsNotDefinedException.php
+++ b/src/Upgrade/Application/Exception/UpgradeStrategyIsNotDefinedException.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Exception;
 
 use Exception;

--- a/src/Upgrade/Application/Exception/UpgradeStrategyIsNotDefinedException.php
+++ b/src/Upgrade/Application/Exception/UpgradeStrategyIsNotDefinedException.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Exception;
 

--- a/src/Upgrade/Application/Exception/UpgradeStrategyIsNotDefinedException.php
+++ b/src/Upgrade/Application/Exception/UpgradeStrategyIsNotDefinedException.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Exception;
 

--- a/src/Upgrade/Application/Exception/UpgraderException.php
+++ b/src/Upgrade/Application/Exception/UpgraderException.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Exception;
 
 use Exception;

--- a/src/Upgrade/Application/Exception/UpgraderException.php
+++ b/src/Upgrade/Application/Exception/UpgraderException.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Exception;
 

--- a/src/Upgrade/Application/Exception/UpgraderException.php
+++ b/src/Upgrade/Application/Exception/UpgraderException.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Exception;
 

--- a/src/Upgrade/Application/Provider/ConfigurationProviderInterface.php
+++ b/src/Upgrade/Application/Provider/ConfigurationProviderInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Provider;
 

--- a/src/Upgrade/Application/Provider/ConfigurationProviderInterface.php
+++ b/src/Upgrade/Application/Provider/ConfigurationProviderInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Provider;
 

--- a/src/Upgrade/Application/Provider/ConfigurationProviderInterface.php
+++ b/src/Upgrade/Application/Provider/ConfigurationProviderInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Provider;
 
 interface ConfigurationProviderInterface

--- a/src/Upgrade/Application/Service/UpgradeService.php
+++ b/src/Upgrade/Application/Service/UpgradeService.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Service;
 
 use Upgrade\Application\Dto\StepsResponseDto;

--- a/src/Upgrade/Application/Service/UpgradeService.php
+++ b/src/Upgrade/Application/Service/UpgradeService.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Service;
 

--- a/src/Upgrade/Application/Service/UpgradeService.php
+++ b/src/Upgrade/Application/Service/UpgradeService.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Service;
 

--- a/src/Upgrade/Application/Service/UpgradeServiceInterface.php
+++ b/src/Upgrade/Application/Service/UpgradeServiceInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Service;
 
 use Upgrade\Application\Dto\StepsResponseDto;

--- a/src/Upgrade/Application/Service/UpgradeServiceInterface.php
+++ b/src/Upgrade/Application/Service/UpgradeServiceInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Service;
 

--- a/src/Upgrade/Application/Service/UpgradeServiceInterface.php
+++ b/src/Upgrade/Application/Service/UpgradeServiceInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Service;
 

--- a/src/Upgrade/Application/Strategy/AbstractStrategy.php
+++ b/src/Upgrade/Application/Strategy/AbstractStrategy.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy;
 

--- a/src/Upgrade/Application/Strategy/AbstractStrategy.php
+++ b/src/Upgrade/Application/Strategy/AbstractStrategy.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy;
 
 use Upgrade\Application\Dto\StepsResponseDto;

--- a/src/Upgrade/Application/Strategy/AbstractStrategy.php
+++ b/src/Upgrade/Application/Strategy/AbstractStrategy.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/AbstractStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/AbstractStep.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/AbstractStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/AbstractStep.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\Common\Step;
 
 use Upgrade\Application\Adapter\VersionControlSystemAdapterInterface;

--- a/src/Upgrade/Application/Strategy/Common/Step/AbstractStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/AbstractStep.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/AddChangesStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/AddChangesStep.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/AddChangesStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/AddChangesStep.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\Common\Step;
 
 use Upgrade\Application\Dto\StepsResponseDto;

--- a/src/Upgrade/Application/Strategy/Common/Step/AddChangesStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/AddChangesStep.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/CheckCredentialsStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/CheckCredentialsStep.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/CheckCredentialsStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/CheckCredentialsStep.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\Common\Step;
 
 use Upgrade\Application\Dto\StepsResponseDto;

--- a/src/Upgrade/Application/Strategy/Common/Step/CheckCredentialsStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/CheckCredentialsStep.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/CheckLocalTargetBranchExistsStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/CheckLocalTargetBranchExistsStep.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/CheckLocalTargetBranchExistsStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/CheckLocalTargetBranchExistsStep.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\Common\Step;
 
 use Upgrade\Application\Dto\StepsResponseDto;

--- a/src/Upgrade/Application/Strategy/Common/Step/CheckLocalTargetBranchExistsStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/CheckLocalTargetBranchExistsStep.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/CheckRemoteTargetBranchExistsStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/CheckRemoteTargetBranchExistsStep.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/CheckRemoteTargetBranchExistsStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/CheckRemoteTargetBranchExistsStep.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\Common\Step;
 
 use Upgrade\Application\Dto\StepsResponseDto;

--- a/src/Upgrade/Application/Strategy/Common/Step/CheckRemoteTargetBranchExistsStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/CheckRemoteTargetBranchExistsStep.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/CheckUncommittedChangesStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/CheckUncommittedChangesStep.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/CheckUncommittedChangesStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/CheckUncommittedChangesStep.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\Common\Step;
 
 use Upgrade\Application\Dto\StepsResponseDto;

--- a/src/Upgrade/Application/Strategy/Common/Step/CheckUncommittedChangesStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/CheckUncommittedChangesStep.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/CheckoutStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/CheckoutStep.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/CheckoutStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/CheckoutStep.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\Common\Step;
 
 use Upgrade\Application\Dto\StepsResponseDto;

--- a/src/Upgrade/Application/Strategy/Common/Step/CheckoutStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/CheckoutStep.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/CommitChangesStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/CommitChangesStep.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/CommitChangesStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/CommitChangesStep.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\Common\Step;
 
 use Upgrade\Application\Dto\StepsResponseDto;

--- a/src/Upgrade/Application/Strategy/Common/Step/CommitChangesStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/CommitChangesStep.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/ComposerLockComparatorStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/ComposerLockComparatorStep.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\Common\Step;
 
 use Upgrade\Application\Adapter\PackageManagerAdapterInterface;

--- a/src/Upgrade/Application/Strategy/Common/Step/ComposerLockComparatorStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/ComposerLockComparatorStep.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/ComposerLockComparatorStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/ComposerLockComparatorStep.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/CreateBranchStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/CreateBranchStep.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/CreateBranchStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/CreateBranchStep.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\Common\Step;
 
 use Upgrade\Application\Dto\StepsResponseDto;

--- a/src/Upgrade/Application/Strategy/Common/Step/CreateBranchStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/CreateBranchStep.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/CreatePullRequestStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/CreatePullRequestStep.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/CreatePullRequestStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/CreatePullRequestStep.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\Common\Step;
 
 use Upgrade\Application\Dto\StepsResponseDto;

--- a/src/Upgrade/Application/Strategy/Common/Step/CreatePullRequestStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/CreatePullRequestStep.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/IntegratorStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/IntegratorStep.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/IntegratorStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/IntegratorStep.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\Common\Step;
 
 use Upgrade\Application\Adapter\IntegratorAdapterInterface;

--- a/src/Upgrade/Application/Strategy/Common/Step/IntegratorStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/IntegratorStep.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/PushChangesStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/PushChangesStep.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Common/Step/PushChangesStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/PushChangesStep.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\Common\Step;
 
 use Upgrade\Application\Dto\StepsResponseDto;

--- a/src/Upgrade/Application/Strategy/Common/Step/PushChangesStep.php
+++ b/src/Upgrade/Application/Strategy/Common/Step/PushChangesStep.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Common\Step;
 

--- a/src/Upgrade/Application/Strategy/Composer/ComposerStrategy.php
+++ b/src/Upgrade/Application/Strategy/Composer/ComposerStrategy.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Composer;
 

--- a/src/Upgrade/Application/Strategy/Composer/ComposerStrategy.php
+++ b/src/Upgrade/Application/Strategy/Composer/ComposerStrategy.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Composer;
 

--- a/src/Upgrade/Application/Strategy/Composer/ComposerStrategy.php
+++ b/src/Upgrade/Application/Strategy/Composer/ComposerStrategy.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\Composer;
 
 use Upgrade\Application\Strategy\AbstractStrategy;

--- a/src/Upgrade/Application/Strategy/Composer/Step/ComposerUpdateStep.php
+++ b/src/Upgrade/Application/Strategy/Composer/Step/ComposerUpdateStep.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Composer\Step;
 

--- a/src/Upgrade/Application/Strategy/Composer/Step/ComposerUpdateStep.php
+++ b/src/Upgrade/Application/Strategy/Composer/Step/ComposerUpdateStep.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\Composer\Step;
 

--- a/src/Upgrade/Application/Strategy/Composer/Step/ComposerUpdateStep.php
+++ b/src/Upgrade/Application/Strategy/Composer/Step/ComposerUpdateStep.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\Composer\Step;
 
 use Upgrade\Application\Adapter\PackageManagerAdapterInterface;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Mapper/PackageCollectionMapper.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Mapper/PackageCollectionMapper.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Mapper;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Mapper/PackageCollectionMapper.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Mapper/PackageCollectionMapper.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\ReleaseApp\Mapper;
 
 use ReleaseApp\Infrastructure\Shared\Dto\Collection\ModuleDtoCollection;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Mapper/PackageCollectionMapper.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Mapper/PackageCollectionMapper.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Mapper;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Mapper/PackageCollectionMapperInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Mapper/PackageCollectionMapperInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Mapper;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Mapper/PackageCollectionMapperInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Mapper/PackageCollectionMapperInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\ReleaseApp\Mapper;
 
 use ReleaseApp\Infrastructure\Shared\Dto\Collection\ModuleDtoCollection;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Mapper/PackageCollectionMapperInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Mapper/PackageCollectionMapperInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Mapper;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Processor/AggregateReleaseGroupProcessor.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Processor/AggregateReleaseGroupProcessor.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Processor;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Processor/AggregateReleaseGroupProcessor.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Processor/AggregateReleaseGroupProcessor.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\ReleaseApp\Processor;
 
 use ReleaseApp\Infrastructure\Shared\Dto\Collection\ModuleDtoCollection;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Processor/AggregateReleaseGroupProcessor.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Processor/AggregateReleaseGroupProcessor.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Processor;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Processor/ReleaseGroupProcessorInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Processor/ReleaseGroupProcessorInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Processor;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Processor/ReleaseGroupProcessorInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Processor/ReleaseGroupProcessorInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\ReleaseApp\Processor;
 
 use ReleaseApp\Infrastructure\Shared\Dto\Collection\ReleaseGroupDtoCollection;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Processor/ReleaseGroupProcessorInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Processor/ReleaseGroupProcessorInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Processor;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Processor/ReleaseGroupProcessorResolver.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Processor/ReleaseGroupProcessorResolver.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Processor;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Processor/ReleaseGroupProcessorResolver.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Processor/ReleaseGroupProcessorResolver.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Processor;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Processor/ReleaseGroupProcessorResolver.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Processor/ReleaseGroupProcessorResolver.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\ReleaseApp\Processor;
 
 use Upgrade\Application\Exception\ReleaseGroupRequireProcessorIsNotDefinedException;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Processor/SequentialReleaseGroupProcessor.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Processor/SequentialReleaseGroupProcessor.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Processor;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Processor/SequentialReleaseGroupProcessor.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Processor/SequentialReleaseGroupProcessor.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\ReleaseApp\Processor;
 
 use ReleaseApp\Infrastructure\Shared\Dto\Collection\ReleaseGroupDtoCollection;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Processor/SequentialReleaseGroupProcessor.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Processor/SequentialReleaseGroupProcessor.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Processor;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/ReleaseAppStrategy.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/ReleaseAppStrategy.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\ReleaseApp;
 
 use Upgrade\Application\Strategy\AbstractStrategy;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/ReleaseAppStrategy.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/ReleaseAppStrategy.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/ReleaseAppStrategy.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/ReleaseAppStrategy.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Step/ReleaseGroupUpdateStep.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Step/ReleaseGroupUpdateStep.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\ReleaseApp\Step;
 
 use Upgrade\Application\Adapter\ReleaseAppClientAdapterInterface;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Step/ReleaseGroupUpdateStep.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Step/ReleaseGroupUpdateStep.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Step;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Step/ReleaseGroupUpdateStep.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Step/ReleaseGroupUpdateStep.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Step;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Package/AlreadyInstalledValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Package/AlreadyInstalledValidator.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\Package;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Package/AlreadyInstalledValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Package/AlreadyInstalledValidator.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\Package;
 
 use Upgrade\Application\Adapter\PackageManagerAdapterInterface;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Package/AlreadyInstalledValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Package/AlreadyInstalledValidator.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\Package;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Package/PackageValidatorInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Package/PackageValidatorInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\Package;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Package/PackageValidatorInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Package/PackageValidatorInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\Package;
 
 use Upgrade\Domain\Entity\Package;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Package/PackageValidatorInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Package/PackageValidatorInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\Package;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/PackageSoftValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/PackageSoftValidator.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator;
 
 use Upgrade\Application\Dto\ResponseDto;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/PackageSoftValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/PackageSoftValidator.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/PackageSoftValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/PackageSoftValidator.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/PackageSoftValidatorInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/PackageSoftValidatorInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator;
 
 use Upgrade\Application\Dto\ResponseDto;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/PackageSoftValidatorInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/PackageSoftValidatorInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/PackageSoftValidatorInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/PackageSoftValidatorInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroup/MajorVersionValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroup/MajorVersionValidator.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\ReleaseGroup;
 
 use ReleaseApp\Infrastructure\Shared\Dto\ReleaseGroupDto;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroup/MajorVersionValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroup/MajorVersionValidator.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\ReleaseGroup;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroup/MajorVersionValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroup/MajorVersionValidator.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\ReleaseGroup;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroup/ProjectChangesValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroup/ProjectChangesValidator.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\ReleaseGroup;
 
 use ReleaseApp\Infrastructure\Shared\Dto\ReleaseGroupDto;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroup/ProjectChangesValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroup/ProjectChangesValidator.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\ReleaseGroup;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroup/ProjectChangesValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroup/ProjectChangesValidator.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\ReleaseGroup;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroup/ReleaseGroupValidatorInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroup/ReleaseGroupValidatorInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\ReleaseGroup;
 
 use ReleaseApp\Infrastructure\Shared\Dto\ReleaseGroupDto;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroup/ReleaseGroupValidatorInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroup/ReleaseGroupValidatorInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\ReleaseGroup;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroup/ReleaseGroupValidatorInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroup/ReleaseGroupValidatorInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\ReleaseGroup;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroupSoftValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroupSoftValidator.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroupSoftValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroupSoftValidator.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroupSoftValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroupSoftValidator.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator;
 
 use ReleaseApp\Infrastructure\Shared\Dto\ReleaseGroupDto;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroupSoftValidatorInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroupSoftValidatorInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroupSoftValidatorInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroupSoftValidatorInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroupSoftValidatorInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ReleaseGroupSoftValidatorInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator;
 
 use ReleaseApp\Infrastructure\Shared\Dto\ReleaseGroupDto;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/MajorThresholdValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/MajorThresholdValidator.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\Threshold;
 
 use ReleaseApp\Infrastructure\Shared\Dto\Collection\ReleaseGroupDtoCollection;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/MajorThresholdValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/MajorThresholdValidator.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\Threshold;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/MajorThresholdValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/MajorThresholdValidator.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\Threshold;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/MinorThresholdValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/MinorThresholdValidator.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\Threshold;
 
 use ReleaseApp\Infrastructure\Shared\Dto\Collection\ReleaseGroupDtoCollection;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/MinorThresholdValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/MinorThresholdValidator.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\Threshold;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/MinorThresholdValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/MinorThresholdValidator.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\Threshold;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/PathThresholdValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/PathThresholdValidator.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\Threshold;
 
 use ReleaseApp\Infrastructure\Shared\Dto\Collection\ReleaseGroupDtoCollection;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/PathThresholdValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/PathThresholdValidator.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\Threshold;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/PathThresholdValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/PathThresholdValidator.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\Threshold;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/ReleaseGroupThresholdValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/ReleaseGroupThresholdValidator.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\Threshold;
 
 use ReleaseApp\Infrastructure\Shared\Dto\Collection\ReleaseGroupDtoCollection;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/ReleaseGroupThresholdValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/ReleaseGroupThresholdValidator.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\Threshold;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/ReleaseGroupThresholdValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/ReleaseGroupThresholdValidator.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\Threshold;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/ThresholdValidatorInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/ThresholdValidatorInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\Threshold;
 
 use ReleaseApp\Infrastructure\Shared\Dto\Collection\ReleaseGroupDtoCollection;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/ThresholdValidatorInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/ThresholdValidatorInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\Threshold;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/ThresholdValidatorInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/Threshold/ThresholdValidatorInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator\Threshold;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ThresholdSoftValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ThresholdSoftValidator.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator;
 
 use ReleaseApp\Infrastructure\Shared\Dto\Collection\ReleaseGroupDtoCollection;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ThresholdSoftValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ThresholdSoftValidator.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ThresholdSoftValidator.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ThresholdSoftValidator.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ThresholdSoftValidatorInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ThresholdSoftValidatorInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator;
 
 use ReleaseApp\Infrastructure\Shared\Dto\Collection\ReleaseGroupDtoCollection;

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ThresholdSoftValidatorInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ThresholdSoftValidatorInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator;
 

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ThresholdSoftValidatorInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Validator/ThresholdSoftValidatorInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy\ReleaseApp\Validator;
 

--- a/src/Upgrade/Application/Strategy/RollbackStepInterface.php
+++ b/src/Upgrade/Application/Strategy/RollbackStepInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy;
 

--- a/src/Upgrade/Application/Strategy/RollbackStepInterface.php
+++ b/src/Upgrade/Application/Strategy/RollbackStepInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy;
 
 use Upgrade\Application\Dto\StepsResponseDto;

--- a/src/Upgrade/Application/Strategy/RollbackStepInterface.php
+++ b/src/Upgrade/Application/Strategy/RollbackStepInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy;
 

--- a/src/Upgrade/Application/Strategy/StepInterface.php
+++ b/src/Upgrade/Application/Strategy/StepInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy;
 

--- a/src/Upgrade/Application/Strategy/StepInterface.php
+++ b/src/Upgrade/Application/Strategy/StepInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy;
 
 use Upgrade\Application\Dto\StepsResponseDto;

--- a/src/Upgrade/Application/Strategy/StepInterface.php
+++ b/src/Upgrade/Application/Strategy/StepInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy;
 

--- a/src/Upgrade/Application/Strategy/StrategyInterface.php
+++ b/src/Upgrade/Application/Strategy/StrategyInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy;
 

--- a/src/Upgrade/Application/Strategy/StrategyInterface.php
+++ b/src/Upgrade/Application/Strategy/StrategyInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy;
 
 use Upgrade\Application\Dto\StepsResponseDto;

--- a/src/Upgrade/Application/Strategy/StrategyInterface.php
+++ b/src/Upgrade/Application/Strategy/StrategyInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy;
 

--- a/src/Upgrade/Application/Strategy/StrategyResolver.php
+++ b/src/Upgrade/Application/Strategy/StrategyResolver.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy;
 

--- a/src/Upgrade/Application/Strategy/StrategyResolver.php
+++ b/src/Upgrade/Application/Strategy/StrategyResolver.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Application\Strategy;
 

--- a/src/Upgrade/Application/Strategy/StrategyResolver.php
+++ b/src/Upgrade/Application/Strategy/StrategyResolver.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Application\Strategy;
 
 use Upgrade\Application\Exception\UpgradeStrategyIsNotDefinedException;

--- a/src/Upgrade/Domain/Entity/Collection/PackageCollection.php
+++ b/src/Upgrade/Domain/Entity/Collection/PackageCollection.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Domain\Entity\Collection;
 

--- a/src/Upgrade/Domain/Entity/Collection/PackageCollection.php
+++ b/src/Upgrade/Domain/Entity/Collection/PackageCollection.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Domain\Entity\Collection;
 

--- a/src/Upgrade/Domain/Entity/Collection/PackageCollection.php
+++ b/src/Upgrade/Domain/Entity/Collection/PackageCollection.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Domain\Entity\Collection;
 
 use Upgrade\Domain\Entity\Package;

--- a/src/Upgrade/Domain/Entity/Message.php
+++ b/src/Upgrade/Domain/Entity/Message.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Domain\Entity;
 

--- a/src/Upgrade/Domain/Entity/Message.php
+++ b/src/Upgrade/Domain/Entity/Message.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Domain\Entity;
 
 use SprykerSdk\SdkContracts\Entity\MessageInterface;

--- a/src/Upgrade/Domain/Entity/Message.php
+++ b/src/Upgrade/Domain/Entity/Message.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Domain\Entity;
 

--- a/src/Upgrade/Domain/Entity/Package.php
+++ b/src/Upgrade/Domain/Entity/Package.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Domain\Entity;
 
 class Package

--- a/src/Upgrade/Domain/Entity/Package.php
+++ b/src/Upgrade/Domain/Entity/Package.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Domain\Entity;
 

--- a/src/Upgrade/Domain/Entity/Package.php
+++ b/src/Upgrade/Domain/Entity/Package.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Domain\Entity;
 

--- a/src/Upgrade/Infrastructure/Adapter/IntegratorAdapter.php
+++ b/src/Upgrade/Infrastructure/Adapter/IntegratorAdapter.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\Adapter;
 
 use Core\Infrastructure\Service\ProcessRunnerServiceInterface;

--- a/src/Upgrade/Infrastructure/Adapter/IntegratorAdapter.php
+++ b/src/Upgrade/Infrastructure/Adapter/IntegratorAdapter.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\Adapter;
 

--- a/src/Upgrade/Infrastructure/Adapter/IntegratorAdapter.php
+++ b/src/Upgrade/Infrastructure/Adapter/IntegratorAdapter.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\Adapter;
 

--- a/src/Upgrade/Infrastructure/Adapter/ReleaseAppClientAdapter.php
+++ b/src/Upgrade/Infrastructure/Adapter/ReleaseAppClientAdapter.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\Adapter;
 
 use ReleaseApp\Domain\Client\Request\UpgradeAnalysisRequest;

--- a/src/Upgrade/Infrastructure/Adapter/ReleaseAppClientAdapter.php
+++ b/src/Upgrade/Infrastructure/Adapter/ReleaseAppClientAdapter.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\Adapter;
 

--- a/src/Upgrade/Infrastructure/Adapter/ReleaseAppClientAdapter.php
+++ b/src/Upgrade/Infrastructure/Adapter/ReleaseAppClientAdapter.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\Adapter;
 

--- a/src/Upgrade/Infrastructure/Configuration/ConfigurationProvider.php
+++ b/src/Upgrade/Infrastructure/Configuration/ConfigurationProvider.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\Configuration;
 

--- a/src/Upgrade/Infrastructure/Configuration/ConfigurationProvider.php
+++ b/src/Upgrade/Infrastructure/Configuration/ConfigurationProvider.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\Configuration;
 

--- a/src/Upgrade/Infrastructure/Configuration/ConfigurationProvider.php
+++ b/src/Upgrade/Infrastructure/Configuration/ConfigurationProvider.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\Configuration;
 
 use Upgrade\Application\Provider\ConfigurationProviderInterface;

--- a/src/Upgrade/Infrastructure/Exception/FileNotFoundException.php
+++ b/src/Upgrade/Infrastructure/Exception/FileNotFoundException.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\Exception;
 

--- a/src/Upgrade/Infrastructure/Exception/FileNotFoundException.php
+++ b/src/Upgrade/Infrastructure/Exception/FileNotFoundException.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\Exception;
 
 use Exception;

--- a/src/Upgrade/Infrastructure/Exception/FileNotFoundException.php
+++ b/src/Upgrade/Infrastructure/Exception/FileNotFoundException.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\Exception;
 

--- a/src/Upgrade/Infrastructure/Exception/SourceCodeProviderIsNotDefinedException.php
+++ b/src/Upgrade/Infrastructure/Exception/SourceCodeProviderIsNotDefinedException.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\Exception;
 

--- a/src/Upgrade/Infrastructure/Exception/SourceCodeProviderIsNotDefinedException.php
+++ b/src/Upgrade/Infrastructure/Exception/SourceCodeProviderIsNotDefinedException.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\Exception;
 
 use Exception;

--- a/src/Upgrade/Infrastructure/Exception/SourceCodeProviderIsNotDefinedException.php
+++ b/src/Upgrade/Infrastructure/Exception/SourceCodeProviderIsNotDefinedException.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\Exception;
 

--- a/src/Upgrade/Infrastructure/Exception/VersionControlSystemAdapterIsNotDefined.php
+++ b/src/Upgrade/Infrastructure/Exception/VersionControlSystemAdapterIsNotDefined.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\Exception;
 

--- a/src/Upgrade/Infrastructure/Exception/VersionControlSystemAdapterIsNotDefined.php
+++ b/src/Upgrade/Infrastructure/Exception/VersionControlSystemAdapterIsNotDefined.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\Exception;
 
 use Exception;

--- a/src/Upgrade/Infrastructure/Exception/VersionControlSystemAdapterIsNotDefined.php
+++ b/src/Upgrade/Infrastructure/Exception/VersionControlSystemAdapterIsNotDefined.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\Exception;
 

--- a/src/Upgrade/Infrastructure/PackageManager/CommandExecutor/ComposerCommandExecutor.php
+++ b/src/Upgrade/Infrastructure/PackageManager/CommandExecutor/ComposerCommandExecutor.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\PackageManager\CommandExecutor;
 

--- a/src/Upgrade/Infrastructure/PackageManager/CommandExecutor/ComposerCommandExecutor.php
+++ b/src/Upgrade/Infrastructure/PackageManager/CommandExecutor/ComposerCommandExecutor.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\PackageManager\CommandExecutor;
 

--- a/src/Upgrade/Infrastructure/PackageManager/CommandExecutor/ComposerCommandExecutor.php
+++ b/src/Upgrade/Infrastructure/PackageManager/CommandExecutor/ComposerCommandExecutor.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\PackageManager\CommandExecutor;
 
 use Core\Infrastructure\Service\ProcessRunnerServiceInterface;

--- a/src/Upgrade/Infrastructure/PackageManager/CommandExecutor/ComposerCommandExecutorInterface.php
+++ b/src/Upgrade/Infrastructure/PackageManager/CommandExecutor/ComposerCommandExecutorInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\PackageManager\CommandExecutor;
 

--- a/src/Upgrade/Infrastructure/PackageManager/CommandExecutor/ComposerCommandExecutorInterface.php
+++ b/src/Upgrade/Infrastructure/PackageManager/CommandExecutor/ComposerCommandExecutorInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\PackageManager\CommandExecutor;
 
 use Upgrade\Application\Dto\ResponseDto;

--- a/src/Upgrade/Infrastructure/PackageManager/CommandExecutor/ComposerCommandExecutorInterface.php
+++ b/src/Upgrade/Infrastructure/PackageManager/CommandExecutor/ComposerCommandExecutorInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\PackageManager\CommandExecutor;
 

--- a/src/Upgrade/Infrastructure/PackageManager/CommandExecutor/ComposerLockComparatorCommandExecutor.php
+++ b/src/Upgrade/Infrastructure/PackageManager/CommandExecutor/ComposerLockComparatorCommandExecutor.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\PackageManager\CommandExecutor;
 

--- a/src/Upgrade/Infrastructure/PackageManager/CommandExecutor/ComposerLockComparatorCommandExecutor.php
+++ b/src/Upgrade/Infrastructure/PackageManager/CommandExecutor/ComposerLockComparatorCommandExecutor.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\PackageManager\CommandExecutor;
 

--- a/src/Upgrade/Infrastructure/PackageManager/CommandExecutor/ComposerLockComparatorCommandExecutor.php
+++ b/src/Upgrade/Infrastructure/PackageManager/CommandExecutor/ComposerLockComparatorCommandExecutor.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\PackageManager\CommandExecutor;
 
 use Core\Infrastructure\Service\ProcessRunnerServiceInterface;

--- a/src/Upgrade/Infrastructure/PackageManager/CommandExecutor/ComposerLockComparatorCommandExecutorInterface.php
+++ b/src/Upgrade/Infrastructure/PackageManager/CommandExecutor/ComposerLockComparatorCommandExecutorInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\PackageManager\CommandExecutor;
 
 use Upgrade\Application\Dto\ComposerLockDiffDto;

--- a/src/Upgrade/Infrastructure/PackageManager/CommandExecutor/ComposerLockComparatorCommandExecutorInterface.php
+++ b/src/Upgrade/Infrastructure/PackageManager/CommandExecutor/ComposerLockComparatorCommandExecutorInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\PackageManager\CommandExecutor;
 

--- a/src/Upgrade/Infrastructure/PackageManager/CommandExecutor/ComposerLockComparatorCommandExecutorInterface.php
+++ b/src/Upgrade/Infrastructure/PackageManager/CommandExecutor/ComposerLockComparatorCommandExecutorInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\PackageManager\CommandExecutor;
 

--- a/src/Upgrade/Infrastructure/PackageManager/ComposerAdapter.php
+++ b/src/Upgrade/Infrastructure/PackageManager/ComposerAdapter.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\PackageManager;
 

--- a/src/Upgrade/Infrastructure/PackageManager/ComposerAdapter.php
+++ b/src/Upgrade/Infrastructure/PackageManager/ComposerAdapter.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\PackageManager;
 
 use Upgrade\Application\Adapter\PackageManagerAdapterInterface;

--- a/src/Upgrade/Infrastructure/PackageManager/ComposerAdapter.php
+++ b/src/Upgrade/Infrastructure/PackageManager/ComposerAdapter.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\PackageManager;
 

--- a/src/Upgrade/Infrastructure/PackageManager/Reader/ComposerJsonReader.php
+++ b/src/Upgrade/Infrastructure/PackageManager/Reader/ComposerJsonReader.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\PackageManager\Reader;
 
 use Upgrade\Infrastructure\Exception\FileNotFoundException;

--- a/src/Upgrade/Infrastructure/PackageManager/Reader/ComposerJsonReader.php
+++ b/src/Upgrade/Infrastructure/PackageManager/Reader/ComposerJsonReader.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\PackageManager\Reader;
 

--- a/src/Upgrade/Infrastructure/PackageManager/Reader/ComposerJsonReader.php
+++ b/src/Upgrade/Infrastructure/PackageManager/Reader/ComposerJsonReader.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\PackageManager\Reader;
 

--- a/src/Upgrade/Infrastructure/PackageManager/Reader/ComposerJsonReaderInterface.php
+++ b/src/Upgrade/Infrastructure/PackageManager/Reader/ComposerJsonReaderInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\PackageManager\Reader;
 

--- a/src/Upgrade/Infrastructure/PackageManager/Reader/ComposerJsonReaderInterface.php
+++ b/src/Upgrade/Infrastructure/PackageManager/Reader/ComposerJsonReaderInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\PackageManager\Reader;
 
 interface ComposerJsonReaderInterface

--- a/src/Upgrade/Infrastructure/PackageManager/Reader/ComposerJsonReaderInterface.php
+++ b/src/Upgrade/Infrastructure/PackageManager/Reader/ComposerJsonReaderInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\PackageManager\Reader;
 

--- a/src/Upgrade/Infrastructure/PackageManager/Reader/ComposerLockReader.php
+++ b/src/Upgrade/Infrastructure/PackageManager/Reader/ComposerLockReader.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\PackageManager\Reader;
 
 use Upgrade\Infrastructure\Exception\FileNotFoundException;

--- a/src/Upgrade/Infrastructure/PackageManager/Reader/ComposerLockReader.php
+++ b/src/Upgrade/Infrastructure/PackageManager/Reader/ComposerLockReader.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\PackageManager\Reader;
 

--- a/src/Upgrade/Infrastructure/PackageManager/Reader/ComposerLockReader.php
+++ b/src/Upgrade/Infrastructure/PackageManager/Reader/ComposerLockReader.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\PackageManager\Reader;
 

--- a/src/Upgrade/Infrastructure/PackageManager/Reader/ComposerLockReaderInterface.php
+++ b/src/Upgrade/Infrastructure/PackageManager/Reader/ComposerLockReaderInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\PackageManager\Reader;
 

--- a/src/Upgrade/Infrastructure/PackageManager/Reader/ComposerLockReaderInterface.php
+++ b/src/Upgrade/Infrastructure/PackageManager/Reader/ComposerLockReaderInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\PackageManager\Reader;
 
 interface ComposerLockReaderInterface

--- a/src/Upgrade/Infrastructure/PackageManager/Reader/ComposerLockReaderInterface.php
+++ b/src/Upgrade/Infrastructure/PackageManager/Reader/ComposerLockReaderInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\PackageManager\Reader;
 

--- a/src/Upgrade/Infrastructure/Service/UpgradeService.php
+++ b/src/Upgrade/Infrastructure/Service/UpgradeService.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\Service;
 
 use Upgrade\Application\Dto\StepsResponseDto;

--- a/src/Upgrade/Infrastructure/Service/UpgradeService.php
+++ b/src/Upgrade/Infrastructure/Service/UpgradeService.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\Service;
 

--- a/src/Upgrade/Infrastructure/Service/UpgradeService.php
+++ b/src/Upgrade/Infrastructure/Service/UpgradeService.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\Service;
 

--- a/src/Upgrade/Infrastructure/Service/UpgradeServiceInterface.php
+++ b/src/Upgrade/Infrastructure/Service/UpgradeServiceInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\Service;
 
 use Upgrade\Application\Dto\StepsResponseDto;

--- a/src/Upgrade/Infrastructure/Service/UpgradeServiceInterface.php
+++ b/src/Upgrade/Infrastructure/Service/UpgradeServiceInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\Service;
 

--- a/src/Upgrade/Infrastructure/Service/UpgradeServiceInterface.php
+++ b/src/Upgrade/Infrastructure/Service/UpgradeServiceInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\Service;
 

--- a/src/Upgrade/Infrastructure/VersionControlSystem/Dto/PullRequestDto.php
+++ b/src/Upgrade/Infrastructure/VersionControlSystem/Dto/PullRequestDto.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\VersionControlSystem\Dto;
 
 class PullRequestDto

--- a/src/Upgrade/Infrastructure/VersionControlSystem/Dto/PullRequestDto.php
+++ b/src/Upgrade/Infrastructure/VersionControlSystem/Dto/PullRequestDto.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\VersionControlSystem\Dto;
 

--- a/src/Upgrade/Infrastructure/VersionControlSystem/Dto/PullRequestDto.php
+++ b/src/Upgrade/Infrastructure/VersionControlSystem/Dto/PullRequestDto.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\VersionControlSystem\Dto;
 

--- a/src/Upgrade/Infrastructure/VersionControlSystem/Generator/PullRequestDataGenerator.php
+++ b/src/Upgrade/Infrastructure/VersionControlSystem/Generator/PullRequestDataGenerator.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\VersionControlSystem\Generator;
 

--- a/src/Upgrade/Infrastructure/VersionControlSystem/Generator/PullRequestDataGenerator.php
+++ b/src/Upgrade/Infrastructure/VersionControlSystem/Generator/PullRequestDataGenerator.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\VersionControlSystem\Generator;
 

--- a/src/Upgrade/Infrastructure/VersionControlSystem/Generator/PullRequestDataGenerator.php
+++ b/src/Upgrade/Infrastructure/VersionControlSystem/Generator/PullRequestDataGenerator.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\VersionControlSystem\Generator;
 
 use Upgrade\Application\Dto\ComposerLockDiffDto;

--- a/src/Upgrade/Infrastructure/VersionControlSystem/Git/Adapter/GitAdapter.php
+++ b/src/Upgrade/Infrastructure/VersionControlSystem/Git/Adapter/GitAdapter.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\VersionControlSystem\Git\Adapter;
 

--- a/src/Upgrade/Infrastructure/VersionControlSystem/Git/Adapter/GitAdapter.php
+++ b/src/Upgrade/Infrastructure/VersionControlSystem/Git/Adapter/GitAdapter.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\VersionControlSystem\Git\Adapter;
 

--- a/src/Upgrade/Infrastructure/VersionControlSystem/Git/Adapter/GitAdapter.php
+++ b/src/Upgrade/Infrastructure/VersionControlSystem/Git/Adapter/GitAdapter.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\VersionControlSystem\Git\Adapter;
 
 use Upgrade\Application\Adapter\VersionControlSystemAdapterInterface;

--- a/src/Upgrade/Infrastructure/VersionControlSystem/Git/Git.php
+++ b/src/Upgrade/Infrastructure/VersionControlSystem/Git/Git.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\VersionControlSystem\Git;
 

--- a/src/Upgrade/Infrastructure/VersionControlSystem/Git/Git.php
+++ b/src/Upgrade/Infrastructure/VersionControlSystem/Git/Git.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\VersionControlSystem\Git;
 

--- a/src/Upgrade/Infrastructure/VersionControlSystem/Git/Git.php
+++ b/src/Upgrade/Infrastructure/VersionControlSystem/Git/Git.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\VersionControlSystem\Git;
 
 use Core\Infrastructure\Service\ProcessRunnerServiceInterface;

--- a/src/Upgrade/Infrastructure/VersionControlSystem/SourceCodeProvider/GitHub/GitHubSourceCodeProvider.php
+++ b/src/Upgrade/Infrastructure/VersionControlSystem/SourceCodeProvider/GitHub/GitHubSourceCodeProvider.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\VersionControlSystem\SourceCodeProvider\GitHub;
 

--- a/src/Upgrade/Infrastructure/VersionControlSystem/SourceCodeProvider/GitHub/GitHubSourceCodeProvider.php
+++ b/src/Upgrade/Infrastructure/VersionControlSystem/SourceCodeProvider/GitHub/GitHubSourceCodeProvider.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\VersionControlSystem\SourceCodeProvider\GitHub;
 
 use Github\AuthMethod;

--- a/src/Upgrade/Infrastructure/VersionControlSystem/SourceCodeProvider/GitHub/GitHubSourceCodeProvider.php
+++ b/src/Upgrade/Infrastructure/VersionControlSystem/SourceCodeProvider/GitHub/GitHubSourceCodeProvider.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\VersionControlSystem\SourceCodeProvider\GitHub;
 

--- a/src/Upgrade/Infrastructure/VersionControlSystem/SourceCodeProvider/GitLab/GitLabSourceCodeProvider.php
+++ b/src/Upgrade/Infrastructure/VersionControlSystem/SourceCodeProvider/GitLab/GitLabSourceCodeProvider.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\VersionControlSystem\SourceCodeProvider\GitLab;
 

--- a/src/Upgrade/Infrastructure/VersionControlSystem/SourceCodeProvider/GitLab/GitLabSourceCodeProvider.php
+++ b/src/Upgrade/Infrastructure/VersionControlSystem/SourceCodeProvider/GitLab/GitLabSourceCodeProvider.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\VersionControlSystem\SourceCodeProvider\GitLab;
 

--- a/src/Upgrade/Infrastructure/VersionControlSystem/SourceCodeProvider/GitLab/GitLabSourceCodeProvider.php
+++ b/src/Upgrade/Infrastructure/VersionControlSystem/SourceCodeProvider/GitLab/GitLabSourceCodeProvider.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\VersionControlSystem\SourceCodeProvider\GitLab;
 
 use Exception;

--- a/src/Upgrade/Infrastructure/VersionControlSystem/SourceCodeProvider/SourceCodeProvider.php
+++ b/src/Upgrade/Infrastructure/VersionControlSystem/SourceCodeProvider/SourceCodeProvider.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\VersionControlSystem\SourceCodeProvider;
 
 use Upgrade\Infrastructure\Configuration\ConfigurationProvider;

--- a/src/Upgrade/Infrastructure/VersionControlSystem/SourceCodeProvider/SourceCodeProvider.php
+++ b/src/Upgrade/Infrastructure/VersionControlSystem/SourceCodeProvider/SourceCodeProvider.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\VersionControlSystem\SourceCodeProvider;
 

--- a/src/Upgrade/Infrastructure/VersionControlSystem/SourceCodeProvider/SourceCodeProvider.php
+++ b/src/Upgrade/Infrastructure/VersionControlSystem/SourceCodeProvider/SourceCodeProvider.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\VersionControlSystem\SourceCodeProvider;
 

--- a/src/Upgrade/Infrastructure/VersionControlSystem/SourceCodeProvider/SourceCodeProviderInterface.php
+++ b/src/Upgrade/Infrastructure/VersionControlSystem/SourceCodeProvider/SourceCodeProviderInterface.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrade\Infrastructure\VersionControlSystem\SourceCodeProvider;
 
 use Upgrade\Application\Dto\StepsResponseDto;

--- a/src/Upgrade/Infrastructure/VersionControlSystem/SourceCodeProvider/SourceCodeProviderInterface.php
+++ b/src/Upgrade/Infrastructure/VersionControlSystem/SourceCodeProvider/SourceCodeProviderInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\VersionControlSystem\SourceCodeProvider;
 

--- a/src/Upgrade/Infrastructure/VersionControlSystem/SourceCodeProvider/SourceCodeProviderInterface.php
+++ b/src/Upgrade/Infrastructure/VersionControlSystem/SourceCodeProvider/SourceCodeProviderInterface.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrade\Infrastructure\VersionControlSystem\SourceCodeProvider;
 

--- a/src/Upgrader/Commands/Evaluate/Analyze/AnalyzeCommand.php
+++ b/src/Upgrader/Commands/Evaluate/Analyze/AnalyzeCommand.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrader\Commands\Evaluate\Analyze;
 
 use Codebase\Application\Dto\CodeBaseRequestDto;

--- a/src/Upgrader/Commands/Evaluate/Analyze/AnalyzeCommand.php
+++ b/src/Upgrader/Commands/Evaluate/Analyze/AnalyzeCommand.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrader\Commands\Evaluate\Analyze;
 

--- a/src/Upgrader/Commands/Evaluate/Analyze/AnalyzeCommand.php
+++ b/src/Upgrader/Commands/Evaluate/Analyze/AnalyzeCommand.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrader\Commands\Evaluate\Analyze;
 

--- a/src/Upgrader/Commands/Evaluate/Report/ReportCommand.php
+++ b/src/Upgrader/Commands/Evaluate/Report/ReportCommand.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrader\Commands\Evaluate\Report;
 
 use SprykerSdk\SdkContracts\Entity\CommandInterface;

--- a/src/Upgrader/Commands/Evaluate/Report/ReportCommand.php
+++ b/src/Upgrader/Commands/Evaluate/Report/ReportCommand.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrader\Commands\Evaluate\Report;
 

--- a/src/Upgrader/Commands/Evaluate/Report/ReportCommand.php
+++ b/src/Upgrader/Commands/Evaluate/Report/ReportCommand.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrader\Commands\Evaluate\Report;
 

--- a/src/Upgrader/Commands/Upgrade/UpgradeCommand.php
+++ b/src/Upgrader/Commands/Upgrade/UpgradeCommand.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrader\Commands\Upgrade;
 
 use SprykerSdk\SdkContracts\Entity\ContextInterface;

--- a/src/Upgrader/Commands/Upgrade/UpgradeCommand.php
+++ b/src/Upgrader/Commands/Upgrade/UpgradeCommand.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrader\Commands\Upgrade;
 

--- a/src/Upgrader/Commands/Upgrade/UpgradeCommand.php
+++ b/src/Upgrader/Commands/Upgrade/UpgradeCommand.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrader\Commands\Upgrade;
 

--- a/src/Upgrader/Configuration/ConfigurationProvider.php
+++ b/src/Upgrader/Configuration/ConfigurationProvider.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrader\Configuration;
 

--- a/src/Upgrader/Configuration/ConfigurationProvider.php
+++ b/src/Upgrader/Configuration/ConfigurationProvider.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrader\Configuration;
 

--- a/src/Upgrader/Configuration/ConfigurationProvider.php
+++ b/src/Upgrader/Configuration/ConfigurationProvider.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrader\Configuration;
 
 class ConfigurationProvider

--- a/src/Upgrader/Console/EvaluateConsole.php
+++ b/src/Upgrader/Console/EvaluateConsole.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrader\Console;
 
 use Codebase\Application\Dto\CodeBaseRequestDto;

--- a/src/Upgrader/Console/EvaluateConsole.php
+++ b/src/Upgrader/Console/EvaluateConsole.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrader\Console;
 

--- a/src/Upgrader/Console/EvaluateConsole.php
+++ b/src/Upgrader/Console/EvaluateConsole.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrader\Console;
 

--- a/src/Upgrader/Console/EvaluationReportConsole.php
+++ b/src/Upgrader/Console/EvaluationReportConsole.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrader\Console;
 
 use Symfony\Component\Console\Command\Command;

--- a/src/Upgrader/Console/EvaluationReportConsole.php
+++ b/src/Upgrader/Console/EvaluationReportConsole.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrader\Console;
 

--- a/src/Upgrader/Console/EvaluationReportConsole.php
+++ b/src/Upgrader/Console/EvaluationReportConsole.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrader\Console;
 

--- a/src/Upgrader/Console/UpgraderConsole.php
+++ b/src/Upgrader/Console/UpgraderConsole.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrader\Console;
 
 use Symfony\Component\Console\Command\Command;

--- a/src/Upgrader/Console/UpgraderConsole.php
+++ b/src/Upgrader/Console/UpgraderConsole.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrader\Console;
 

--- a/src/Upgrader/Console/UpgraderConsole.php
+++ b/src/Upgrader/Console/UpgraderConsole.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrader\Console;
 

--- a/src/Upgrader/Lifecycle/Lifecycle.php
+++ b/src/Upgrader/Lifecycle/Lifecycle.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrader\Lifecycle;
 

--- a/src/Upgrader/Lifecycle/Lifecycle.php
+++ b/src/Upgrader/Lifecycle/Lifecycle.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrader\Lifecycle;
 
 use SprykerSdk\SdkContracts\Entity\Lifecycle\LifecycleInterface;

--- a/src/Upgrader/Lifecycle/Lifecycle.php
+++ b/src/Upgrader/Lifecycle/Lifecycle.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrader\Lifecycle;
 

--- a/src/Upgrader/Report/Event/ReportListener.php
+++ b/src/Upgrader/Report/Event/ReportListener.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrader\Report\Event;
 
 use Symfony\Component\Console\Command\Command;

--- a/src/Upgrader/Report/Event/ReportListener.php
+++ b/src/Upgrader/Report/Event/ReportListener.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrader\Report\Event;
 

--- a/src/Upgrader/Report/Event/ReportListener.php
+++ b/src/Upgrader/Report/Event/ReportListener.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrader\Report\Event;
 

--- a/src/Upgrader/Report/Service/ReportService.php
+++ b/src/Upgrader/Report/Service/ReportService.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrader\Report\Service;
 

--- a/src/Upgrader/Report/Service/ReportService.php
+++ b/src/Upgrader/Report/Service/ReportService.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrader\Report\Service;
 
 use CodeCompliance\Domain\Entity\Report;

--- a/src/Upgrader/Report/Service/ReportService.php
+++ b/src/Upgrader/Report/Service/ReportService.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrader\Report\Service;
 

--- a/src/Upgrader/Tasks/Evaluate/Analyze/AnalyzeTask.php
+++ b/src/Upgrader/Tasks/Evaluate/Analyze/AnalyzeTask.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrader\Tasks\Evaluate\Analyze;
 
 use Codebase\Infrastructure\Service\CodebaseService;

--- a/src/Upgrader/Tasks/Evaluate/Analyze/AnalyzeTask.php
+++ b/src/Upgrader/Tasks/Evaluate/Analyze/AnalyzeTask.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrader\Tasks\Evaluate\Analyze;
 

--- a/src/Upgrader/Tasks/Evaluate/Analyze/AnalyzeTask.php
+++ b/src/Upgrader/Tasks/Evaluate/Analyze/AnalyzeTask.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrader\Tasks\Evaluate\Analyze;
 

--- a/src/Upgrader/Tasks/Evaluate/Report/ReportTask.php
+++ b/src/Upgrader/Tasks/Evaluate/Report/ReportTask.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrader\Tasks\Evaluate\Report;
 
 use SprykerSdk\SdkContracts\Entity\Lifecycle\LifecycleInterface;

--- a/src/Upgrader/Tasks/Evaluate/Report/ReportTask.php
+++ b/src/Upgrader/Tasks/Evaluate/Report/ReportTask.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrader\Tasks\Evaluate\Report;
 

--- a/src/Upgrader/Tasks/Evaluate/Report/ReportTask.php
+++ b/src/Upgrader/Tasks/Evaluate/Report/ReportTask.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrader\Tasks\Evaluate\Report;
 

--- a/src/Upgrader/Tasks/Upgrade/UpgradeTask.php
+++ b/src/Upgrader/Tasks/Upgrade/UpgradeTask.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrader\Tasks\Upgrade;
 

--- a/src/Upgrader/Tasks/Upgrade/UpgradeTask.php
+++ b/src/Upgrader/Tasks/Upgrade/UpgradeTask.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrader\Tasks\Upgrade;
 
 use SprykerSdk\SdkContracts\Entity\Lifecycle\LifecycleInterface;

--- a/src/Upgrader/Tasks/Upgrade/UpgradeTask.php
+++ b/src/Upgrader/Tasks/Upgrade/UpgradeTask.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrader\Tasks\Upgrade;
 

--- a/src/Upgrader/UpgraderBundle.php
+++ b/src/Upgrader/UpgraderBundle.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrader;
 

--- a/src/Upgrader/UpgraderBundle.php
+++ b/src/Upgrader/UpgraderBundle.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrader;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;

--- a/src/Upgrader/UpgraderBundle.php
+++ b/src/Upgrader/UpgraderBundle.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrader;
 

--- a/src/Upgrader/UpgraderExtension.php
+++ b/src/Upgrader/UpgraderExtension.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace Upgrader;
 
 use Symfony\Component\Config\FileLocator;

--- a/src/Upgrader/UpgraderExtension.php
+++ b/src/Upgrader/UpgraderExtension.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace Upgrader;
 

--- a/src/Upgrader/UpgraderExtension.php
+++ b/src/Upgrader/UpgraderExtension.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace Upgrader;
 

--- a/tests/CodeComplianceTest/Domain/Checks/BaseCodeComplianceCheckTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/BaseCodeComplianceCheckTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks;
 

--- a/tests/CodeComplianceTest/Domain/Checks/BaseCodeComplianceCheckTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/BaseCodeComplianceCheckTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks;
 

--- a/tests/CodeComplianceTest/Domain/Checks/BaseCodeComplianceCheckTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/BaseCodeComplianceCheckTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/BaseFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/BaseFilterTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\Filters;
 

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/BaseFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/BaseFilterTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks\Filters;
 
 use Codebase\Application\Dto\ClassCodebaseDto;

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/BaseFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/BaseFilterTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\Filters;
 

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/BusinessFactoryFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/BusinessFactoryFilterTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\Filters;
 

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/BusinessFactoryFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/BusinessFactoryFilterTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks\Filters;
 
 use CodeCompliance\Domain\Checks\Filters\BusinessFactoryFilter;

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/BusinessFactoryFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/BusinessFactoryFilterTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\Filters;
 

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/BusinessModelFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/BusinessModelFilterTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\Filters;
 

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/BusinessModelFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/BusinessModelFilterTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks\Filters;
 
 use CodeCompliance\Domain\Checks\Filters\BusinessModelFilter;

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/BusinessModelFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/BusinessModelFilterTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\Filters;
 

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/CoreExtensionFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/CoreExtensionFilterTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks\Filters;
 
 use CodeCompliance\Domain\Checks\Filters\CoreExtensionFilter;

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/CoreExtensionFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/CoreExtensionFilterTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\Filters;
 

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/CoreExtensionFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/CoreExtensionFilterTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\Filters;
 

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/FacadeFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/FacadeFilterTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\Filters;
 

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/FacadeFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/FacadeFilterTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\Filters;
 

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/FacadeFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/FacadeFilterTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks\Filters;
 
 use CodeCompliance\Domain\Checks\Filters\FacadeFilter;

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/IgnoreListFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/IgnoreListFilterTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\Filters;
 

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/IgnoreListFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/IgnoreListFilterTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks\Filters;
 
 use Codebase\Application\Dto\ClassCodebaseDto;

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/IgnoreListFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/IgnoreListFilterTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\Filters;
 

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/PersistenceFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/PersistenceFilterTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\Filters;
 

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/PersistenceFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/PersistenceFilterTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks\Filters;
 
 use CodeCompliance\Domain\Checks\Filters\PersistenceFilter;

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/PersistenceFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/PersistenceFilterTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\Filters;
 

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/PluginFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/PluginFilterTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\Filters;
 

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/PluginFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/PluginFilterTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks\Filters;
 
 use Codebase\Application\Dto\ClassCodebaseDto;

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/PluginFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/PluginFilterTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\Filters;
 

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/PrivateApiFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/PrivateApiFilterTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\Filters;
 

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/PrivateApiFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/PrivateApiFilterTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks\Filters;
 
 use CodeCompliance\Domain\Checks\Filters\PrivateApiFilter;

--- a/tests/CodeComplianceTest/Domain/Checks/Filters/PrivateApiFilterTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/Filters/PrivateApiFilterTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\Filters;
 

--- a/tests/CodeComplianceTest/Domain/Checks/NotUnique/ConstantTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/NotUnique/ConstantTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\NotUnique;
 

--- a/tests/CodeComplianceTest/Domain/Checks/NotUnique/ConstantTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/NotUnique/ConstantTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks\NotUnique;
 
 use CodeCompliance\Domain\Checks\NotUnique\Constant;

--- a/tests/CodeComplianceTest/Domain/Checks/NotUnique/ConstantTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/NotUnique/ConstantTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\NotUnique;
 

--- a/tests/CodeComplianceTest/Domain/Checks/NotUnique/DatabaseColumnTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/NotUnique/DatabaseColumnTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks\NotUnique;
 
 use CodeCompliance\Domain\Checks\NotUnique\DatabaseColumn;

--- a/tests/CodeComplianceTest/Domain/Checks/NotUnique/DatabaseColumnTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/NotUnique/DatabaseColumnTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\NotUnique;
 

--- a/tests/CodeComplianceTest/Domain/Checks/NotUnique/DatabaseColumnTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/NotUnique/DatabaseColumnTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\NotUnique;
 

--- a/tests/CodeComplianceTest/Domain/Checks/NotUnique/DatabaseTableTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/NotUnique/DatabaseTableTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\NotUnique;
 

--- a/tests/CodeComplianceTest/Domain/Checks/NotUnique/DatabaseTableTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/NotUnique/DatabaseTableTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks\NotUnique;
 
 use CodeCompliance\Domain\Checks\NotUnique\DatabaseTable;

--- a/tests/CodeComplianceTest/Domain/Checks/NotUnique/DatabaseTableTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/NotUnique/DatabaseTableTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\NotUnique;
 

--- a/tests/CodeComplianceTest/Domain/Checks/NotUnique/MethodTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/NotUnique/MethodTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\NotUnique;
 

--- a/tests/CodeComplianceTest/Domain/Checks/NotUnique/MethodTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/NotUnique/MethodTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks\NotUnique;
 
 use CodeCompliance\Domain\Checks\Filters\PluginFilter;

--- a/tests/CodeComplianceTest/Domain/Checks/NotUnique/MethodTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/NotUnique/MethodTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\NotUnique;
 

--- a/tests/CodeComplianceTest/Domain/Checks/NotUnique/TransferNameTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/NotUnique/TransferNameTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\NotUnique;
 

--- a/tests/CodeComplianceTest/Domain/Checks/NotUnique/TransferNameTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/NotUnique/TransferNameTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\NotUnique;
 

--- a/tests/CodeComplianceTest/Domain/Checks/NotUnique/TransferNameTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/NotUnique/TransferNameTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks\NotUnique;
 
 use CodeCompliance\Domain\Checks\NotUnique\TransferName;

--- a/tests/CodeComplianceTest/Domain/Checks/NotUnique/TransferPropertyTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/NotUnique/TransferPropertyTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\NotUnique;
 

--- a/tests/CodeComplianceTest/Domain/Checks/NotUnique/TransferPropertyTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/NotUnique/TransferPropertyTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks\NotUnique;
 
 use CodeCompliance\Domain\Checks\NotUnique\TransferProperty;

--- a/tests/CodeComplianceTest/Domain/Checks/NotUnique/TransferPropertyTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/NotUnique/TransferPropertyTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\NotUnique;
 

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Extended/ExtendedTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Extended/ExtendedTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\Extended;
 

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Extended/ExtendedTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Extended/ExtendedTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\Extended;
 
 use CodeCompliance\Domain\Checks\PrivateApi\Extended\Extended;

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Extended/ExtendedTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Extended/ExtendedTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\Extended;
 

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/MethodOverwritten/MethodIsOverwrittenTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/MethodOverwritten/MethodIsOverwrittenTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\MethodIsOverwritten;
 

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/MethodOverwritten/MethodIsOverwrittenTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/MethodOverwritten/MethodIsOverwrittenTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\MethodIsOverwritten;
 

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/MethodOverwritten/MethodIsOverwrittenTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/MethodOverwritten/MethodIsOverwrittenTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\MethodIsOverwritten;
 
 use CodeCompliance\Domain\Checks\PrivateApi\MethodOverwritten\MethodIsOverwritten;

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/CorePersistenceTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/CorePersistenceTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\Used;
 

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/CorePersistenceTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/CorePersistenceTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\Used;
 

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/CorePersistenceTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/CorePersistenceTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\Used;
 
 use CodeCompliance\Domain\Checks\PrivateApi\Used\CorePersistence;

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/DependencyInBusinessModelTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/DependencyInBusinessModelTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\Used;
 

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/DependencyInBusinessModelTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/DependencyInBusinessModelTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\Used;
 

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/DependencyInBusinessModelTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/DependencyInBusinessModelTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\Used;
 
 use CodeCompliance\Domain\Checks\PrivateApi\Used\DependencyInBusinessModel;

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/DependencyProviderTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/DependencyProviderTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\Used;
 

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/DependencyProviderTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/DependencyProviderTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\Used;
 

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/DependencyProviderTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/DependencyProviderTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\Used;
 
 use CodeCompliance\Domain\Checks\PrivateApi\Used\DependencyProvider;

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/FacadeTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/FacadeTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\Used;
 

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/FacadeTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/FacadeTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\Used;
 
 use CodeCompliance\Domain\Checks\PrivateApi\Used\Facade;

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/FacadeTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/FacadeTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\Used;
 

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/ObjectIsInitializedInBusinessModelTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/ObjectIsInitializedInBusinessModelTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\Used;
 

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/ObjectIsInitializedInBusinessModelTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/ObjectIsInitializedInBusinessModelTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\Used;
 
 use CodeCompliance\Domain\Checks\PrivateApi\Used\ObjectIsInitializedInBusinessModel;

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/ObjectIsInitializedInBusinessModelTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/ObjectIsInitializedInBusinessModelTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\Used;
 

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/PersistenceInBusinessModelTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/PersistenceInBusinessModelTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\Used;
 

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/PersistenceInBusinessModelTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/PersistenceInBusinessModelTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\Used;
 

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/PersistenceInBusinessModelTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/PersistenceInBusinessModelTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\Used;
 
 use CodeCompliance\Domain\Checks\PrivateApi\Used\PersistenceInBusinessModel;

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/PersistenceTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/PersistenceTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\Used;
 

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/PersistenceTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/PersistenceTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\Used;
 

--- a/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/PersistenceTest.php
+++ b/tests/CodeComplianceTest/Domain/Checks/PrivateApi/Used/PersistenceTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodeComplianceTest\Domain\Checks\PrivateApi\Used;
 
 use CodeCompliance\Domain\Checks\PrivateApi\Used\Persistence;

--- a/tests/CodebaseTest/Infrastructure/CodeBaseReader/Mapper/ModuleOptionMapperMapperTest.php
+++ b/tests/CodebaseTest/Infrastructure/CodeBaseReader/Mapper/ModuleOptionMapperMapperTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodebaseTest\Infrastructure\CodeBaseReader\Mapper;
 
 use Codebase\Application\Dto\ModuleDto;

--- a/tests/CodebaseTest/Infrastructure/CodeBaseReader/Mapper/ModuleOptionMapperMapperTest.php
+++ b/tests/CodebaseTest/Infrastructure/CodeBaseReader/Mapper/ModuleOptionMapperMapperTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodebaseTest\Infrastructure\CodeBaseReader\Mapper;
 

--- a/tests/CodebaseTest/Infrastructure/CodeBaseReader/Mapper/ModuleOptionMapperMapperTest.php
+++ b/tests/CodebaseTest/Infrastructure/CodeBaseReader/Mapper/ModuleOptionMapperMapperTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodebaseTest\Infrastructure\CodeBaseReader\Mapper;
 

--- a/tests/CodebaseTest/Infrastructure/CodeBaseReader/Mapper/SourceParserRequestMapperTest.php
+++ b/tests/CodebaseTest/Infrastructure/CodeBaseReader/Mapper/SourceParserRequestMapperTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodebaseTest\Infrastructure\CodeBaseReader\Mapper;
 

--- a/tests/CodebaseTest/Infrastructure/CodeBaseReader/Mapper/SourceParserRequestMapperTest.php
+++ b/tests/CodebaseTest/Infrastructure/CodeBaseReader/Mapper/SourceParserRequestMapperTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodebaseTest\Infrastructure\CodeBaseReader\Mapper;
 
 use Codebase\Application\Dto\CodeBaseRequestDto;

--- a/tests/CodebaseTest/Infrastructure/CodeBaseReader/Mapper/SourceParserRequestMapperTest.php
+++ b/tests/CodebaseTest/Infrastructure/CodeBaseReader/Mapper/SourceParserRequestMapperTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodebaseTest\Infrastructure\CodeBaseReader\Mapper;
 

--- a/tests/CodebaseTest/Infrastructure/ProjectConfigurationParser/ProjectConfigurationParserTest.php
+++ b/tests/CodebaseTest/Infrastructure/ProjectConfigurationParser/ProjectConfigurationParserTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodebaseTest\Infrastructure\ProjectConfigurationParser;
 

--- a/tests/CodebaseTest/Infrastructure/ProjectConfigurationParser/ProjectConfigurationParserTest.php
+++ b/tests/CodebaseTest/Infrastructure/ProjectConfigurationParser/ProjectConfigurationParserTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodebaseTest\Infrastructure\ProjectConfigurationParser;
 

--- a/tests/CodebaseTest/Infrastructure/ProjectConfigurationParser/ProjectConfigurationParserTest.php
+++ b/tests/CodebaseTest/Infrastructure/ProjectConfigurationParser/ProjectConfigurationParserTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodebaseTest\Infrastructure\ProjectConfigurationParser;
 
 use Codebase\Infrastructure\Exception\ProjectConfigurationFileInvalidSyntaxException;

--- a/tests/CodebaseTest/Infrastructure/Service/CodebaseServiceTest.php
+++ b/tests/CodebaseTest/Infrastructure/Service/CodebaseServiceTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodebaseTest\Infrastructure\Service;
 

--- a/tests/CodebaseTest/Infrastructure/Service/CodebaseServiceTest.php
+++ b/tests/CodebaseTest/Infrastructure/Service/CodebaseServiceTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodebaseTest\Infrastructure\Service;
 

--- a/tests/CodebaseTest/Infrastructure/Service/CodebaseServiceTest.php
+++ b/tests/CodebaseTest/Infrastructure/Service/CodebaseServiceTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodebaseTest\Infrastructure\Service;
 
 use Codebase\Application\Dto\SourceParserRequestDto;

--- a/tests/CodebaseTest/Infrastructure/SourceParser/Parser/BaseParser.php
+++ b/tests/CodebaseTest/Infrastructure/SourceParser/Parser/BaseParser.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodebaseTest\Infrastructure\SourceParser\Parser;
 

--- a/tests/CodebaseTest/Infrastructure/SourceParser/Parser/BaseParser.php
+++ b/tests/CodebaseTest/Infrastructure/SourceParser/Parser/BaseParser.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodebaseTest\Infrastructure\SourceParser\Parser;
 

--- a/tests/CodebaseTest/Infrastructure/SourceParser/Parser/BaseParser.php
+++ b/tests/CodebaseTest/Infrastructure/SourceParser/Parser/BaseParser.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodebaseTest\Infrastructure\SourceParser\Parser;
 
 use Codebase\Application\Dto\CodebaseSourceDto;

--- a/tests/CodebaseTest/Infrastructure/SourceParser/Parser/DatabaseSchemaParserTest.php
+++ b/tests/CodebaseTest/Infrastructure/SourceParser/Parser/DatabaseSchemaParserTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodebaseTest\Infrastructure\SourceParser\Parser;
 

--- a/tests/CodebaseTest/Infrastructure/SourceParser/Parser/DatabaseSchemaParserTest.php
+++ b/tests/CodebaseTest/Infrastructure/SourceParser/Parser/DatabaseSchemaParserTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodebaseTest\Infrastructure\SourceParser\Parser;
 

--- a/tests/CodebaseTest/Infrastructure/SourceParser/Parser/DatabaseSchemaParserTest.php
+++ b/tests/CodebaseTest/Infrastructure/SourceParser/Parser/DatabaseSchemaParserTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodebaseTest\Infrastructure\SourceParser\Parser;
 
 use Codebase\Infrastructure\SourceParser\Parser\DatabaseSchemaParser;

--- a/tests/CodebaseTest/Infrastructure/SourceParser/Parser/PhpParserTest.php
+++ b/tests/CodebaseTest/Infrastructure/SourceParser/Parser/PhpParserTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodebaseTest\Infrastructure\SourceParser\Parser;
 

--- a/tests/CodebaseTest/Infrastructure/SourceParser/Parser/PhpParserTest.php
+++ b/tests/CodebaseTest/Infrastructure/SourceParser/Parser/PhpParserTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodebaseTest\Infrastructure\SourceParser\Parser;
 

--- a/tests/CodebaseTest/Infrastructure/SourceParser/Parser/PhpParserTest.php
+++ b/tests/CodebaseTest/Infrastructure/SourceParser/Parser/PhpParserTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodebaseTest\Infrastructure\SourceParser\Parser;
 
 use Codebase\Infrastructure\SourceParser\Parser\PhpParser;

--- a/tests/CodebaseTest/Infrastructure/SourceParser/Parser/TransferSchemaParserTest.php
+++ b/tests/CodebaseTest/Infrastructure/SourceParser/Parser/TransferSchemaParserTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CodebaseTest\Infrastructure\SourceParser\Parser;
 

--- a/tests/CodebaseTest/Infrastructure/SourceParser/Parser/TransferSchemaParserTest.php
+++ b/tests/CodebaseTest/Infrastructure/SourceParser/Parser/TransferSchemaParserTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CodebaseTest\Infrastructure\SourceParser\Parser;
 

--- a/tests/CodebaseTest/Infrastructure/SourceParser/Parser/TransferSchemaParserTest.php
+++ b/tests/CodebaseTest/Infrastructure/SourceParser/Parser/TransferSchemaParserTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CodebaseTest\Infrastructure\SourceParser\Parser;
 
 use Codebase\Infrastructure\SourceParser\Parser\TransferSchemaParser;

--- a/tests/Core/App/Kernel/TestKernel.php
+++ b/tests/Core/App/Kernel/TestKernel.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace CoreTest\App\Kernel;
 

--- a/tests/Core/App/Kernel/TestKernel.php
+++ b/tests/Core/App/Kernel/TestKernel.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace CoreTest\App\Kernel;
 
 use Symfony\Component\Config\Loader\LoaderInterface;

--- a/tests/Core/App/Kernel/TestKernel.php
+++ b/tests/Core/App/Kernel/TestKernel.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace CoreTest\App\Kernel;
 

--- a/tests/UpgradeTest/Application/Dto/ResponseDtoTest.php
+++ b/tests/UpgradeTest/Application/Dto/ResponseDtoTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace UpgradeTest\Application\Dto;
 

--- a/tests/UpgradeTest/Application/Dto/ResponseDtoTest.php
+++ b/tests/UpgradeTest/Application/Dto/ResponseDtoTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace UpgradeTest\Application\Dto;
 
 use Generator;

--- a/tests/UpgradeTest/Application/Dto/ResponseDtoTest.php
+++ b/tests/UpgradeTest/Application/Dto/ResponseDtoTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace UpgradeTest\Application\Dto;
 

--- a/tests/UpgradeTest/Application/Service/UpgradeServiceTest.php
+++ b/tests/UpgradeTest/Application/Service/UpgradeServiceTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace UpgradeTest\Application\Service;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;

--- a/tests/UpgradeTest/Application/Service/UpgradeServiceTest.php
+++ b/tests/UpgradeTest/Application/Service/UpgradeServiceTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace UpgradeTest\Application\Service;
 

--- a/tests/UpgradeTest/Application/Service/UpgradeServiceTest.php
+++ b/tests/UpgradeTest/Application/Service/UpgradeServiceTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace UpgradeTest\Application\Service;
 

--- a/tests/UpgradeTest/Application/Strategy/Common/Step/ComposerLockComparatorStepTest.php
+++ b/tests/UpgradeTest/Application/Strategy/Common/Step/ComposerLockComparatorStepTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace UpgradeTest\Application\Strategy\Common\Step;
 

--- a/tests/UpgradeTest/Application/Strategy/Common/Step/ComposerLockComparatorStepTest.php
+++ b/tests/UpgradeTest/Application/Strategy/Common/Step/ComposerLockComparatorStepTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace UpgradeTest\Application\Strategy\Common\Step;
 

--- a/tests/UpgradeTest/Application/Strategy/Common/Step/ComposerLockComparatorStepTest.php
+++ b/tests/UpgradeTest/Application/Strategy/Common/Step/ComposerLockComparatorStepTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace UpgradeTest\Application\Strategy\Common\Step;
 
 use Core\Infrastructure\Service\ProcessRunnerService;

--- a/tests/UpgradeTest/Application/Strategy/Composer/ComposerStrategyTest.php
+++ b/tests/UpgradeTest/Application/Strategy/Composer/ComposerStrategyTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace UpgradeTest\Application\Strategy\Composer;
 

--- a/tests/UpgradeTest/Application/Strategy/Composer/ComposerStrategyTest.php
+++ b/tests/UpgradeTest/Application/Strategy/Composer/ComposerStrategyTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace UpgradeTest\Application\Strategy\Composer;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/UpgradeTest/Application/Strategy/Composer/ComposerStrategyTest.php
+++ b/tests/UpgradeTest/Application/Strategy/Composer/ComposerStrategyTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace UpgradeTest\Application\Strategy\Composer;
 

--- a/tests/UpgradeTest/Application/Strategy/ReleaseApp/Mapper/PackageCollectionMapperTest.php
+++ b/tests/UpgradeTest/Application/Strategy/ReleaseApp/Mapper/PackageCollectionMapperTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace UpgradeTest\Application\Strategy\ReleaseApp\Mapper;
 

--- a/tests/UpgradeTest/Application/Strategy/ReleaseApp/Mapper/PackageCollectionMapperTest.php
+++ b/tests/UpgradeTest/Application/Strategy/ReleaseApp/Mapper/PackageCollectionMapperTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace UpgradeTest\Application\Strategy\ReleaseApp\Mapper;
 

--- a/tests/UpgradeTest/Application/Strategy/ReleaseApp/Mapper/PackageCollectionMapperTest.php
+++ b/tests/UpgradeTest/Application/Strategy/ReleaseApp/Mapper/PackageCollectionMapperTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace UpgradeTest\Application\Strategy\ReleaseApp\Mapper;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/UpgradeTest/Application/Strategy/StrategyResolverTest.php
+++ b/tests/UpgradeTest/Application/Strategy/StrategyResolverTest.php
@@ -1,11 +1,10 @@
 <?php
+declare(strict_types=1);
 
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace UpgradeTest\Application\Strategy;
 

--- a/tests/UpgradeTest/Application/Strategy/StrategyResolverTest.php
+++ b/tests/UpgradeTest/Application/Strategy/StrategyResolverTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace UpgradeTest\Application\Strategy;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;

--- a/tests/UpgradeTest/Application/Strategy/StrategyResolverTest.php
+++ b/tests/UpgradeTest/Application/Strategy/StrategyResolverTest.php
@@ -1,10 +1,11 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace UpgradeTest\Application\Strategy;
 

--- a/tests/UpgradeTest/Infrastructure/PackageManager/CommandExecutor/ComposerCommandExecutorTest.php
+++ b/tests/UpgradeTest/Infrastructure/PackageManager/CommandExecutor/ComposerCommandExecutorTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace UpgradeTest\Infrastructure\PackageManager\CommandExecutor;
 
 use Core\Infrastructure\Service\ProcessRunnerService;

--- a/tests/UpgradeTest/Infrastructure/PackageManager/CommandExecutor/ComposerCommandExecutorTest.php
+++ b/tests/UpgradeTest/Infrastructure/PackageManager/CommandExecutor/ComposerCommandExecutorTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace UpgradeTest\Infrastructure\PackageManager\CommandExecutor;
 

--- a/tests/UpgradeTest/Infrastructure/PackageManager/CommandExecutor/ComposerCommandExecutorTest.php
+++ b/tests/UpgradeTest/Infrastructure/PackageManager/CommandExecutor/ComposerCommandExecutorTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace UpgradeTest\Infrastructure\PackageManager\CommandExecutor;
 

--- a/tests/UpgradeTest/Infrastructure/PackageManager/CommandExecutor/ComposerLockComparatorCommandExecutorTest.php
+++ b/tests/UpgradeTest/Infrastructure/PackageManager/CommandExecutor/ComposerLockComparatorCommandExecutorTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace UpgradeTest\Infrastructure\PackageManager\CommandExecutor;
 
 use Core\Infrastructure\Service\ProcessRunnerService;

--- a/tests/UpgradeTest/Infrastructure/PackageManager/CommandExecutor/ComposerLockComparatorCommandExecutorTest.php
+++ b/tests/UpgradeTest/Infrastructure/PackageManager/CommandExecutor/ComposerLockComparatorCommandExecutorTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace UpgradeTest\Infrastructure\PackageManager\CommandExecutor;
 

--- a/tests/UpgradeTest/Infrastructure/PackageManager/CommandExecutor/ComposerLockComparatorCommandExecutorTest.php
+++ b/tests/UpgradeTest/Infrastructure/PackageManager/CommandExecutor/ComposerLockComparatorCommandExecutorTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace UpgradeTest\Infrastructure\PackageManager\CommandExecutor;
 

--- a/tests/UpgradeTest/Infrastructure/PackageManager/Reader/ComposerJsonReaderTest.php
+++ b/tests/UpgradeTest/Infrastructure/PackageManager/Reader/ComposerJsonReaderTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace UpgradeTest\Infrastructure\PackageManager\Reader;
 

--- a/tests/UpgradeTest/Infrastructure/PackageManager/Reader/ComposerJsonReaderTest.php
+++ b/tests/UpgradeTest/Infrastructure/PackageManager/Reader/ComposerJsonReaderTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace UpgradeTest\Infrastructure\PackageManager\Reader;
 

--- a/tests/UpgradeTest/Infrastructure/PackageManager/Reader/ComposerJsonReaderTest.php
+++ b/tests/UpgradeTest/Infrastructure/PackageManager/Reader/ComposerJsonReaderTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace UpgradeTest\Infrastructure\PackageManager\Reader;
 
 use Exception;

--- a/tests/UpgradeTest/Infrastructure/PackageManager/Reader/ComposerLockReaderTest.php
+++ b/tests/UpgradeTest/Infrastructure/PackageManager/Reader/ComposerLockReaderTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace UpgradeTest\Infrastructure\PackageManager\Reader;
 

--- a/tests/UpgradeTest/Infrastructure/PackageManager/Reader/ComposerLockReaderTest.php
+++ b/tests/UpgradeTest/Infrastructure/PackageManager/Reader/ComposerLockReaderTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace UpgradeTest\Infrastructure\PackageManager\Reader;
 

--- a/tests/UpgradeTest/Infrastructure/PackageManager/Reader/ComposerLockReaderTest.php
+++ b/tests/UpgradeTest/Infrastructure/PackageManager/Reader/ComposerLockReaderTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace UpgradeTest\Infrastructure\PackageManager\Reader;
 
 use Exception;

--- a/tests/UpgradeTest/Infrastructure/VersionControlSystem/Git/GitTest.php
+++ b/tests/UpgradeTest/Infrastructure/VersionControlSystem/Git/GitTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace UpgradeTest\Infrastructure\VersionControlSystem\Git;
 

--- a/tests/UpgradeTest/Infrastructure/VersionControlSystem/Git/GitTest.php
+++ b/tests/UpgradeTest/Infrastructure/VersionControlSystem/Git/GitTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace UpgradeTest\Infrastructure\VersionControlSystem\Git;
 
 use Core\Infrastructure\Service\ProcessRunnerService;

--- a/tests/UpgradeTest/Infrastructure/VersionControlSystem/Git/GitTest.php
+++ b/tests/UpgradeTest/Infrastructure/VersionControlSystem/Git/GitTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace UpgradeTest\Infrastructure\VersionControlSystem\Git;
 

--- a/tests/UpgradeTest/Infrastructure/VersionControlSystem/SourceCodeProvider/SourceCodeProviderTest.php
+++ b/tests/UpgradeTest/Infrastructure/VersionControlSystem/SourceCodeProvider/SourceCodeProviderTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace UpgradeTest\Infrastructure\VersionControlSystem\SourceCodeProvider;
 

--- a/tests/UpgradeTest/Infrastructure/VersionControlSystem/SourceCodeProvider/SourceCodeProviderTest.php
+++ b/tests/UpgradeTest/Infrastructure/VersionControlSystem/SourceCodeProvider/SourceCodeProviderTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace UpgradeTest\Infrastructure\VersionControlSystem\SourceCodeProvider;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;

--- a/tests/UpgradeTest/Infrastructure/VersionControlSystem/SourceCodeProvider/SourceCodeProviderTest.php
+++ b/tests/UpgradeTest/Infrastructure/VersionControlSystem/SourceCodeProvider/SourceCodeProviderTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace UpgradeTest\Infrastructure\VersionControlSystem\SourceCodeProvider;
 

--- a/tests/UpgraderTest/UpgraderExtensionTest.php
+++ b/tests/UpgraderTest/UpgraderExtensionTest.php
@@ -1,11 +1,11 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
+
+declare(strict_types=1);
 
 namespace UpgraderTest;
 

--- a/tests/UpgraderTest/UpgraderExtensionTest.php
+++ b/tests/UpgraderTest/UpgraderExtensionTest.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
-
-declare(strict_types=1);
 
 namespace UpgraderTest;
 

--- a/tests/UpgraderTest/UpgraderExtensionTest.php
+++ b/tests/UpgraderTest/UpgraderExtensionTest.php
@@ -5,6 +5,8 @@
  * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
  */
 
+declare(strict_types=1);
+
 namespace UpgraderTest;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,3 @@
 <?php
 
-declare(strict_types=1);
-
 define('APPLICATION_ROOT_DIR', dirname(__DIR__, 1));

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,5 @@
 <?php
 
+declare(strict_types=1);
+
 define('APPLICATION_ROOT_DIR', dirname(__DIR__, 1));


### PR DESCRIPTION
Introduce the usage of strict types in project:

- use `declare(strict_types=1);` in project classes
- fix issues that appeared because of that

Code changes description:
- All changed files contain added line `declare(strict_types=1);`
- Because of strict types usage, it's required now to convert object of \Core\Domain\ValueObject\Id class into string by calling of constructor of \CodeCompliance\Domain\Entity\Violation class. 
Example:

before: `new Violation(new Id(), $guideline, $this->getName());`
now: `new Violation((string)(new Id()), $guideline, $this->getName());`

- Because of strict types usage, it's also required to change the PHPDocs inside of `src/Codebase/Application/Dto/ClassCodebaseDto.php` class - https://github.com/spryker-sdk/upgrader/pull/69/files#diff-35d5179a2578967bfbfbbb7695cf26e325fe51d7b5bfd22154ca14cc53976a80 
