### PR TITLE
Extend PHPCS with strict_types check rule

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -17,5 +17,6 @@
     <file>tests/</file>
 
     <rule ref="vendor/spryker/code-sniffer/SprykerStrict/ruleset.xml"/>
+    <rule ref="Generic.PHP.RequireStrictTypes" />
 
 </ruleset>


### PR DESCRIPTION
PHPCS rule is added to make sure that php files use strict_types.

Merge this PR only after https://github.com/spryker-sdk/upgrader/pull/69 will be merged