### PR TITLE
PPLUS-1624: code-compliance-report command outputs the report twice

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -31,7 +31,7 @@ Note: File synchronization is enabled by the default
 export COMPOSE_DOCKER_CLI_BUILD=1
 
 docker-compose -f linux-compose.yml up -d --build`
-docker exec -it {contaiter_id} bash
+docker exec -it -u spryker upgrader_upgrader-sdk_1 bash
 cd /data/project
 ../bin/upgrader {command_name}
 ```

--- a/src/Upgrader/Console/EvaluateConsole.php
+++ b/src/Upgrader/Console/EvaluateConsole.php
@@ -114,12 +114,10 @@ class EvaluateConsole extends Command
         );
 
         $codebaseSourceDto = $this->codebaseService->readCodeBase($codebaseRequestDto);
-
         $report = $this->codeComplianceService->analyze($codebaseSourceDto);
+        $this->reportService->save($report);
 
         if ($report->hasError()) {
-            $this->reportService->save($report);
-
             return Command::FAILURE;
         }
 

--- a/src/Upgrader/Report/Event/ReportListener.php
+++ b/src/Upgrader/Report/Event/ReportListener.php
@@ -13,15 +13,9 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Upgrader\Report\Service\ReportService;
 use Upgrader\Tasks\Evaluate\Analyze\AnalyzeTask;
-use Upgrader\Tasks\Evaluate\Report\ReportTask;
 
 class ReportListener
 {
-    /**
-     * @var string
-     */
-    protected const KEY_VIOLATIONS = 'violations';
-
     /**
      * @var \Upgrader\Report\Service\ReportService
      */
@@ -42,22 +36,17 @@ class ReportListener
      */
     public function onConsoleCommandTerminate(ConsoleTerminateEvent $event): void
     {
-        if (
-            $event->getCommand() &&
-            (
-                $event->getCommand()->getName() === ReportTask::ID_REPORT_TASK ||
-                $event->getCommand()->getName() === AnalyzeTask::ID_ANALYZE_TASK
-            )
-        ) {
-            $messages = $this->reportService->report();
-
-            if (!$messages) {
-                return;
-            }
-
-            $event->getOutput()->writeln((array)$messages);
-            $event->getOutput()->writeln('Total messages: ' . count((array)$messages));
-            $event->setExitCode(Command::FAILURE);
+        if ($event->getCommand() && $event->getCommand()->getName() !== AnalyzeTask::ID_ANALYZE_TASK) {
+            return;
         }
+
+        $messages = $this->reportService->report();
+        if (!$messages) {
+            return;
+        }
+
+        $event->getOutput()->writeln((array)$messages);
+        $event->getOutput()->writeln('Total messages: ' . count((array)$messages));
+        $event->setExitCode(Command::FAILURE);
     }
 }


### PR DESCRIPTION
Ticket: https://spryker.atlassian.net/browse/PPLUS-1624

* Fixed: code-compliance-report command outputs the report twice
* Fixed: evaluate command does not clear report file if issue were not found
* Updated development environment start command