### PR TITLE
PPLUS-1626: Rename the evaluator rule

### DIFF
--- a/src/CodeCompliance/Domain/Checks/PrivateApi/Used/DependencyInBusinessModel.php
+++ b/src/CodeCompliance/Domain/Checks/PrivateApi/Used/DependencyInBusinessModel.php
@@ -25,7 +25,7 @@ class DependencyInBusinessModel extends AbstractUsedCodeComplianceCheck
      */
     public function getName(): string
     {
-        return 'PrivateApi:PrivateApiDependencyInBusinessModel';
+        return 'PrivateApi:DependencyInBusinessModel';
     }
 
     /**


### PR DESCRIPTION
Rename evaluator rule:

PrivateApi:PrivateApiDependencyInBusinessModel -> PrivateApi:DependencyInBusinessModel

to make it compatible with standard evaluator rule naming convention