### PR TITLE
PPLUS-1790: Extend upgrader service with output of count of processed release groups

### DIFF
--- a/src/Upgrade/Application/Strategy/ReleaseApp/Processor/AggregateReleaseGroupProcessor.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Processor/AggregateReleaseGroupProcessor.php
@@ -102,9 +102,11 @@ class AggregateReleaseGroupProcessor implements ReleaseGroupProcessorInterface
             $stepsExecutionDto->addOutputMessage($requireResult->getOutputMessage());
         }
 
-        $stepsExecutionDto->addOutputMessage(
-            sprintf('Amount of applied release groups: %s', $aggregatedReleaseGroupCollection->count()),
-        );
+        if ($aggregatedReleaseGroupCollection->count()) {
+            $stepsExecutionDto->addOutputMessage(
+                sprintf('Amount of applied release groups: %s', $aggregatedReleaseGroupCollection->count()),
+            );
+        }
 
         return $stepsExecutionDto;
     }

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Processor/AggregateReleaseGroupProcessor.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Processor/AggregateReleaseGroupProcessor.php
@@ -69,15 +69,15 @@ class AggregateReleaseGroupProcessor implements ReleaseGroupProcessorInterface
     }
 
     /**
-     * @param \ReleaseApp\Infrastructure\Shared\Dto\Collection\ReleaseGroupDtoCollection $requiteRequestCollection
+     * @param \ReleaseApp\Infrastructure\Shared\Dto\Collection\ReleaseGroupDtoCollection $requireRequestCollection
      * @param \Upgrade\Application\Dto\StepsResponseDto $stepsExecutionDto
      *
      * @return \Upgrade\Application\Dto\StepsResponseDto
      */
-    public function process(ReleaseGroupDtoCollection $requiteRequestCollection, StepsResponseDto $stepsExecutionDto): StepsResponseDto
+    public function process(ReleaseGroupDtoCollection $requireRequestCollection, StepsResponseDto $stepsExecutionDto): StepsResponseDto
     {
         $aggregatedReleaseGroupCollection = new ReleaseGroupDtoCollection();
-        foreach ($requiteRequestCollection->toArray() as $releaseGroup) {
+        foreach ($requireRequestCollection->toArray() as $releaseGroup) {
             $thresholdValidationResult = $this->thresholdValidator->validate($aggregatedReleaseGroupCollection);
             if (!$thresholdValidationResult->isSuccessful()) {
                 $stepsExecutionDto->addOutputMessage($thresholdValidationResult->getOutputMessage());
@@ -101,6 +101,10 @@ class AggregateReleaseGroupProcessor implements ReleaseGroupProcessorInterface
             $stepsExecutionDto->setIsSuccessful(false);
             $stepsExecutionDto->addOutputMessage($requireResult->getOutputMessage());
         }
+
+        $stepsExecutionDto->addOutputMessage(
+            sprintf('Amount of applied release groups: %s', $aggregatedReleaseGroupCollection->count()),
+        );
 
         return $stepsExecutionDto;
     }

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Processor/ReleaseGroupProcessorInterface.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Processor/ReleaseGroupProcessorInterface.php
@@ -20,13 +20,13 @@ interface ReleaseGroupProcessorInterface
     public function getProcessorName(): string;
 
     /**
-     * @param \ReleaseApp\Infrastructure\Shared\Dto\Collection\ReleaseGroupDtoCollection $requiteRequestCollection
+     * @param \ReleaseApp\Infrastructure\Shared\Dto\Collection\ReleaseGroupDtoCollection $requireRequestCollection
      * @param \Upgrade\Application\Dto\StepsResponseDto $stepsExecutionDto
      *
      * @return \Upgrade\Application\Dto\StepsResponseDto
      */
     public function process(
-        ReleaseGroupDtoCollection $requiteRequestCollection,
+        ReleaseGroupDtoCollection $requireRequestCollection,
         StepsResponseDto $stepsExecutionDto
     ): StepsResponseDto;
 }

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Processor/SequentialReleaseGroupProcessor.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Processor/SequentialReleaseGroupProcessor.php
@@ -69,16 +69,16 @@ class SequentialReleaseGroupProcessor implements ReleaseGroupProcessorInterface
     }
 
     /**
-     * @param \ReleaseApp\Infrastructure\Shared\Dto\Collection\ReleaseGroupDtoCollection $requiteRequestCollection
+     * @param \ReleaseApp\Infrastructure\Shared\Dto\Collection\ReleaseGroupDtoCollection $requireRequestCollection
      * @param \Upgrade\Application\Dto\StepsResponseDto $stepsExecutionDto
      *
      * @return \Upgrade\Application\Dto\StepsResponseDto
      */
-    public function process(ReleaseGroupDtoCollection $requiteRequestCollection, StepsResponseDto $stepsExecutionDto): StepsResponseDto
+    public function process(ReleaseGroupDtoCollection $requireRequestCollection, StepsResponseDto $stepsExecutionDto): StepsResponseDto
     {
         $aggregatedReleaseGroupCollection = new ReleaseGroupDtoCollection();
 
-        foreach ($requiteRequestCollection->toArray() as $releaseGroup) {
+        foreach ($requireRequestCollection->toArray() as $releaseGroup) {
             $thresholdValidationResult = $this->thresholdValidator->validate($aggregatedReleaseGroupCollection);
             if (!$thresholdValidationResult->isSuccessful()) {
                 $stepsExecutionDto->addOutputMessage($thresholdValidationResult->getOutputMessage());
@@ -103,6 +103,10 @@ class SequentialReleaseGroupProcessor implements ReleaseGroupProcessorInterface
                 break;
             }
         }
+
+        $stepsExecutionDto->addOutputMessage(
+            sprintf('Amount of applied release groups: %s', $aggregatedReleaseGroupCollection->count()),
+        );
 
         return $stepsExecutionDto;
     }

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Processor/SequentialReleaseGroupProcessor.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Processor/SequentialReleaseGroupProcessor.php
@@ -104,9 +104,11 @@ class SequentialReleaseGroupProcessor implements ReleaseGroupProcessorInterface
             }
         }
 
-        $stepsExecutionDto->addOutputMessage(
-            sprintf('Amount of applied release groups: %s', $aggregatedReleaseGroupCollection->count()),
-        );
+        if ($aggregatedReleaseGroupCollection->count()) {
+            $stepsExecutionDto->addOutputMessage(
+                sprintf('Amount of applied release groups: %s', $aggregatedReleaseGroupCollection->count()),
+            );
+        }
 
         return $stepsExecutionDto;
     }

--- a/src/Upgrade/Application/Strategy/ReleaseApp/Step/ReleaseGroupUpdateStep.php
+++ b/src/Upgrade/Application/Strategy/ReleaseApp/Step/ReleaseGroupUpdateStep.php
@@ -46,8 +46,12 @@ class ReleaseGroupUpdateStep implements StepInterface
      */
     public function run(StepsResponseDto $stepsExecutionDto): StepsResponseDto
     {
-        $dataProviderResponse = $this->packageManagementSystemBridge->getNewReleaseGroups();
+        $requireRequestCollection = $this->packageManagementSystemBridge->getNewReleaseGroups()->getReleaseGroupCollection();
 
-        return $this->releaseGroupProcessor->process($dataProviderResponse->getReleaseGroupCollection(), $stepsExecutionDto);
+        $stepsExecutionDto->addOutputMessage(
+            sprintf('Amount of available release groups for the project: %s', $requireRequestCollection->count()),
+        );
+
+        return $this->releaseGroupProcessor->process($requireRequestCollection, $stepsExecutionDto);
     }
 }

--- a/tests/UpgradeTest/Application/Strategy/ReleaseApp/Step/ReleaseGroupUpdateStepTest.php
+++ b/tests/UpgradeTest/Application/Strategy/ReleaseApp/Step/ReleaseGroupUpdateStepTest.php
@@ -1,0 +1,265 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+declare(strict_types=1);
+
+namespace UpgradeTest\Application\Strategy\ReleaseApp\Step;
+
+use PHPUnit\Framework\TestCase;
+use ReleaseApp\Infrastructure\Shared\Dto\Collection\ModuleDtoCollection;
+use ReleaseApp\Infrastructure\Shared\Dto\Collection\ReleaseGroupDtoCollection;
+use ReleaseApp\Infrastructure\Shared\Dto\ModuleDto;
+use ReleaseApp\Infrastructure\Shared\Dto\ReleaseAppResponse;
+use ReleaseApp\Infrastructure\Shared\Dto\ReleaseGroupDto;
+use Upgrade\Application\Dto\ResponseDto;
+use Upgrade\Application\Dto\StepsResponseDto;
+use Upgrade\Application\Strategy\ReleaseApp\Mapper\PackageCollectionMapper;
+use Upgrade\Application\Strategy\ReleaseApp\Processor\AggregateReleaseGroupProcessor;
+use Upgrade\Application\Strategy\ReleaseApp\Processor\ReleaseGroupProcessorInterface;
+use Upgrade\Application\Strategy\ReleaseApp\Processor\ReleaseGroupProcessorResolver;
+use Upgrade\Application\Strategy\ReleaseApp\Processor\SequentialReleaseGroupProcessor;
+use Upgrade\Application\Strategy\ReleaseApp\Step\ReleaseGroupUpdateStep;
+use Upgrade\Application\Strategy\ReleaseApp\Validator\PackageSoftValidator;
+use Upgrade\Application\Strategy\ReleaseApp\Validator\ReleaseGroupSoftValidator;
+use Upgrade\Application\Strategy\ReleaseApp\Validator\ThresholdSoftValidator;
+use Upgrade\Infrastructure\Adapter\ReleaseAppClientAdapter;
+use Upgrade\Infrastructure\PackageManager\ComposerAdapter;
+
+class ReleaseGroupUpdateStepTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testRunWithAggregateReleaseGroupProcessor(): void
+    {
+        // Arrange
+        $step = new ReleaseGroupUpdateStep(
+            $this->creteReleaseAppClientAdapterMock(
+                $this->buildReleaseGroupDtoCollection(),
+            ),
+            $this->creteReleaseGroupProcessorResolverMock(
+                $this->createAggregateReleaseGroupProcessor(),
+            ),
+        );
+
+        $stepsResponseDto = new StepsResponseDto();
+
+        // Act
+        $stepsResponseDto = $step->run($stepsResponseDto);
+
+        // Assert
+        $this->assertTrue($stepsResponseDto->isSuccessful());
+        $this->assertSame(
+            implode(PHP_EOL, [
+            'Amount of available release groups for the project: 2',
+            'Amount of applied release groups: 2',
+            ]),
+            $stepsResponseDto->getOutputMessage(),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessWithAggregateReleaseGroupProcessorAndEmptyReleaseGroupDtoCollection(): void
+    {
+        // Arrange
+        $releaseGroupDtoCollection = new ReleaseGroupDtoCollection();
+        $step = new ReleaseGroupUpdateStep(
+            $this->creteReleaseAppClientAdapterMock($releaseGroupDtoCollection),
+            $this->creteReleaseGroupProcessorResolverMock(
+                $this->createAggregateReleaseGroupProcessor(),
+            ),
+        );
+        $stepsResponseDto = new StepsResponseDto();
+
+        // Act
+        $stepsResponseDto = $step->run($stepsResponseDto);
+
+        // Assert
+        $this->assertTrue($stepsResponseDto->isSuccessful());
+        $this->assertSame(
+            implode(PHP_EOL, [
+            'Amount of available release groups for the project: 0',
+            ]),
+            $stepsResponseDto->getOutputMessage(),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testRunWithSequentialReleaseGroupProcessor(): void
+    {
+        // Arrange
+        $step = new ReleaseGroupUpdateStep(
+            $this->creteReleaseAppClientAdapterMock(
+                $this->buildReleaseGroupDtoCollection(),
+            ),
+            $this->creteReleaseGroupProcessorResolverMock(
+                $this->createSequentialReleaseGroupProcessor(),
+            ),
+        );
+
+        $stepsResponseDto = new StepsResponseDto();
+
+        // Act
+        $stepsResponseDto = $step->run($stepsResponseDto);
+
+        // Assert
+        $this->assertTrue($stepsResponseDto->isSuccessful());
+        $this->assertSame(
+            implode(PHP_EOL, [
+            'Amount of available release groups for the project: 2',
+            'Amount of applied release groups: 2',
+            ]),
+            $stepsResponseDto->getOutputMessage(),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testProcessWithSequentialReleaseGroupProcessorAndEmptyReleaseGroupDtoCollection(): void
+    {
+        // Arrange
+        $releaseGroupDtoCollection = new ReleaseGroupDtoCollection();
+        $step = new ReleaseGroupUpdateStep(
+            $this->creteReleaseAppClientAdapterMock($releaseGroupDtoCollection),
+            $this->creteReleaseGroupProcessorResolverMock(
+                $this->createSequentialReleaseGroupProcessor(),
+            ),
+        );
+        $stepsResponseDto = new StepsResponseDto();
+
+        // Act
+        $stepsResponseDto = $step->run($stepsResponseDto);
+
+        // Assert
+        $this->assertTrue($stepsResponseDto->isSuccessful());
+        $this->assertSame(
+            implode(PHP_EOL, [
+            'Amount of available release groups for the project: 0',
+            ]),
+            $stepsResponseDto->getOutputMessage(),
+        );
+    }
+
+    /**
+     * @param \Upgrade\Application\Strategy\ReleaseApp\Processor\ReleaseGroupProcessorInterface $processor
+     *
+     * @return \Upgrade\Application\Strategy\ReleaseApp\Processor\ReleaseGroupProcessorResolver
+     */
+    protected function creteReleaseGroupProcessorResolverMock(ReleaseGroupProcessorInterface $processor): ReleaseGroupProcessorResolver
+    {
+        $composerAdapterMock = $this->getMockBuilder(ReleaseGroupProcessorResolver::class)
+            ->disableOriginalConstructor()
+            ->disableArgumentCloning()
+            ->disallowMockingUnknownTypes()
+            ->getMock();
+        $composerAdapterMock->method('getProcessor')->willReturn($processor);
+
+        return $composerAdapterMock;
+    }
+
+    /**
+     * @param \ReleaseApp\Infrastructure\Shared\Dto\Collection\ReleaseGroupDtoCollection $releaseGroupDtoCollection
+     *
+     * @return \Upgrade\Infrastructure\Adapter\ReleaseAppClientAdapter
+     */
+    protected function creteReleaseAppClientAdapterMock(ReleaseGroupDtoCollection $releaseGroupDtoCollection): ReleaseAppClientAdapter
+    {
+        $releaseAppResponse = new ReleaseAppResponse($releaseGroupDtoCollection);
+        $composerAdapterMock = $this->getMockBuilder(ReleaseAppClientAdapter::class)
+            ->disableOriginalConstructor()
+            ->disableArgumentCloning()
+            ->disallowMockingUnknownTypes()
+            ->getMock();
+        $composerAdapterMock->method('getNewReleaseGroups')->willReturn($releaseAppResponse);
+
+        return $composerAdapterMock;
+    }
+
+    /**
+     * @return \Upgrade\Application\Strategy\ReleaseApp\Processor\AggregateReleaseGroupProcessor
+     */
+    protected function createAggregateReleaseGroupProcessor(): AggregateReleaseGroupProcessor
+    {
+        $responseDto = new ResponseDto(true);
+
+        $composerAdapterMock = $this->getMockBuilder(ComposerAdapter::class)
+            ->disableOriginalConstructor()
+            ->disableArgumentCloning()
+            ->disallowMockingUnknownTypes()
+            ->getMock();
+        $composerAdapterMock->method('require')->willReturn($responseDto);
+        $composerAdapterMock->method('requireDev')->willReturn($responseDto);
+        $composerAdapterMock->method('isDevPackage')->willReturn(false);
+
+        return new AggregateReleaseGroupProcessor(
+            new ReleaseGroupSoftValidator([]),
+            new ThresholdSoftValidator([]),
+            new PackageCollectionMapper(
+                new PackageSoftValidator([]),
+                $composerAdapterMock,
+            ),
+            $composerAdapterMock,
+        );
+    }
+
+    /**
+     * @return \Upgrade\Application\Strategy\ReleaseApp\Processor\SequentialReleaseGroupProcessor
+     */
+    protected function createSequentialReleaseGroupProcessor(): SequentialReleaseGroupProcessor
+    {
+        $responseDto = new ResponseDto(true);
+
+        $composerAdapterMock = $this->getMockBuilder(ComposerAdapter::class)
+            ->disableOriginalConstructor()
+            ->disableArgumentCloning()
+            ->disallowMockingUnknownTypes()
+            ->getMock();
+        $composerAdapterMock->method('require')->willReturn($responseDto);
+        $composerAdapterMock->method('requireDev')->willReturn($responseDto);
+        $composerAdapterMock->method('isDevPackage')->willReturn(false);
+
+        return new SequentialReleaseGroupProcessor(
+            new ReleaseGroupSoftValidator([]),
+            new ThresholdSoftValidator([]),
+            new PackageCollectionMapper(
+                new PackageSoftValidator([]),
+                $composerAdapterMock,
+            ),
+            $composerAdapterMock,
+        );
+    }
+
+    /**
+     * @return \ReleaseApp\Infrastructure\Shared\Dto\Collection\ReleaseGroupDtoCollection
+     */
+    protected function buildReleaseGroupDtoCollection(): ReleaseGroupDtoCollection
+    {
+        return new ReleaseGroupDtoCollection([
+            new ReleaseGroupDto(
+                'RG1',
+                new ModuleDtoCollection([
+                    new ModuleDto('spryker/product-category', '4.17.0', 'minor'),
+                ]),
+                false,
+                'https://api.release.spryker.com/release-groups/view/1',
+            ),
+            new ReleaseGroupDto(
+                'RG2',
+                new ModuleDtoCollection([
+                    new ModuleDto('spryker/oauth-backend-api', '1.1.1', 'path'),
+                ]),
+                true,
+                'https://api.release.spryker.com/release-groups/view/2',
+            ),
+        ]);
+    }
+}


### PR DESCRIPTION
Ticket: https://spryker.atlassian.net/browse/PPLUS-1790

Change log: 
* Added console output with a count of available and installed release groups 